### PR TITLE
Add a skeleton test

### DIFF
--- a/components/BUILD.gn
+++ b/components/BUILD.gn
@@ -1128,6 +1128,7 @@ if (use_blink) {
       "//components/paint_preview/renderer",
       "//components/password_manager/content/browser",
       "//components/performance_manager:browser_tests",
+      "//components/secure_embed/browser:browser_tests",
       "//components/security_state/content",
       "//components/security_state/core",
       "//components/shared_highlighting/core/common",

--- a/components/secure_embed/browser/BUILD.gn
+++ b/components/secure_embed/browser/BUILD.gn
@@ -1,0 +1,18 @@
+# Copyright 2025 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("browser_tests") {
+  testonly = true
+  sources = [ "secure_embed_browsertest.cc" ]
+
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+  public_deps = [
+    "//base/test:test_support",
+    "//content/public/browser",
+    "//content/shell:content_shell_lib",
+    "//content/test:browsertest_support",
+    "//content/test:test_support",
+  ]
+}

--- a/components/secure_embed/browser/secure_embed_browsertest.cc
+++ b/components/secure_embed/browser/secure_embed_browsertest.cc
@@ -1,0 +1,39 @@
+// Copyright 2025 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/memory/raw_ptr.h"
+#include "base/strings/utf_string_conversions.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/content_browser_test.h"
+#include "content/shell/browser/shell.h"
+
+namespace content_capture {
+
+static constexpr char kTestUrl[] = "/secure_embed/embed_tag.html";
+
+class SecureEmbedBrowserTest : public content::ContentBrowserTest {
+ public:
+  void SetUpOnMainThread() override {
+    content::ContentBrowserTest::SetUpOnMainThread();
+    embedded_test_server()->ServeFilesFromSourceDirectory(
+        "components/test/data");
+    ASSERT_TRUE(embedded_test_server()->Start());
+    const GURL test_url = embedded_test_server()->GetURL(kTestUrl);
+    ASSERT_TRUE(NavigateToURL(web_contents(), test_url));
+  }
+
+  void TearDownOnMainThread() override {
+    content::ContentBrowserTest::TearDownOnMainThread();
+  }
+
+  content::WebContents* web_contents() { return shell()->web_contents(); }
+};
+
+IN_PROC_BROWSER_TEST_F(SecureEmbedBrowserTest, EmbedTagCreatesPlugin) {
+  // TODO: add expection of the creation of SecureEmbedHost and other browser
+  // side objects.
+}
+
+}  // namespace content_capture

--- a/components/secure_embed/browser/secure_embed_browsertest.cc
+++ b/components/secure_embed/browser/secure_embed_browsertest.cc
@@ -32,7 +32,7 @@ class SecureEmbedBrowserTest : public content::ContentBrowserTest {
 };
 
 IN_PROC_BROWSER_TEST_F(SecureEmbedBrowserTest, EmbedTagCreatesPlugin) {
-  // TODO: add expection of the creation of SecureEmbedHost and other browser
+  // TODO: add expectations of the creation of SecureEmbedHost and other browser
   // side objects.
 }
 

--- a/components/test/data/secure_embed/embed_tag.html
+++ b/components/test/data/secure_embed/embed_tag.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<embed />
+</body>
+</html>

--- a/components/test/data/secure_embed/embed_tag.html
+++ b/components/test/data/secure_embed/embed_tag.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-<embed />
+<embed type="application/x-google-secure-embed" />
 </body>
 </html>


### PR DESCRIPTION
This PR adds `SecureEmbedBrowserTest.EmbedTagCreatesPlugin` under `components_browsertests`. Run it with 

`./out/Default/components_browsertests --gtest_filter=SecureEmbedBrowserTest.EmbedTagCreatesPlugin`

The test loads a skeleton test file under `components/test/data/secure_embed/embed_tag.html` that contains a `<embed type="application/x-google-secure-embed" />`. The test does not verifies if `<embed>` actually loads - it currently shows a "This plugin is not supported" but there is no easy way to detect plugin support programmatically.