### PR TITLE
Add secure_embed::MayCreatePlugin()

### DIFF
--- a/chrome/renderer/BUILD.gn
+++ b/chrome/renderer/BUILD.gn
@@ -8,6 +8,7 @@ import("//chrome/common/features.gni")
 import("//chrome/common/request_header_integrity/buildflags.gni")
 import("//components/offline_pages/buildflags/features.gni")
 import("//components/optimization_guide/features.gni")
+import("//components/secure_embed/buildflags/buildflags.gni")
 import("//components/signin/features.gni")
 import("//components/spellcheck/spellcheck_build_features.gni")
 import("//content/public/common/features.gni")
@@ -191,6 +192,7 @@ static_library("renderer") {
     "//components/safe_browsing/core/common",
     "//components/safe_browsing/core/common:interfaces",
     "//components/search",
+    "//components/secure_embed/buildflags",
     "//components/security_interstitials/content/renderer",
     "//components/security_interstitials/core:",
     "//components/security_interstitials/core/common/mojom:",
@@ -267,6 +269,10 @@ static_library("renderer") {
 
   if (enable_request_header_integrity) {
     deps += [ "//chrome/common/request_header_integrity" ]
+  }
+
+  if (enable_secure_embed) {
+    deps += [ "//components/secure_embed/renderer" ]
   }
 
   if (enable_widevine_cdm_component) {

--- a/chrome/renderer/chrome_content_renderer_client.cc
+++ b/chrome/renderer/chrome_content_renderer_client.cc
@@ -117,6 +117,7 @@
 #include "components/safe_browsing/content/renderer/threat_dom_details.h"
 #include "components/sampling_profiler/process_type.h"
 #include "components/sampling_profiler/thread_profiler.h"
+#include "components/secure_embed/buildflags/buildflags.h"
 #include "components/security_interstitials/content/renderer/security_interstitial_page_controller_delegate_impl.h"
 #include "components/spellcheck/spellcheck_buildflags.h"
 #include "components/subresource_filter/content/renderer/subresource_filter_agent.h"
@@ -241,6 +242,10 @@
 
 #if BUILDFLAG(ENABLE_PAINT_PREVIEW)
 #include "components/paint_preview/renderer/paint_preview_recorder_impl.h"  // nogncheck
+#endif
+
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+#include "components/secure_embed/renderer/create_plugin.h"
 #endif
 
 #if BUILDFLAG(ENABLE_SPELLCHECK)
@@ -889,6 +894,12 @@ bool ChromeContentRendererClient::OverrideCreatePlugin(
   if (!extensions::ExtensionsRendererClient::Get()->OverrideCreatePlugin(
           render_frame, params)) {
     return false;
+  }
+#endif
+
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+  if (secure_embed::MayCreatePlugin(render_frame, params, plugin)) {
+    return true;
   }
 #endif
 

--- a/components/secure_embed/browser/secure_embed_browsertest.cc
+++ b/components/secure_embed/browser/secure_embed_browsertest.cc
@@ -13,6 +13,9 @@ namespace content_capture {
 
 static constexpr char kTestUrl[] = "/secure_embed/embed_tag.html";
 
+// TODO(secure-embed): This needs to be in //chrome/test where a plugin is
+// is instantiated by the embedder via ContentRenderClient. ContentBrowserTest
+// uses content shell and does not override ContentRenderClient.
 class SecureEmbedBrowserTest : public content::ContentBrowserTest {
  public:
   void SetUpOnMainThread() override {
@@ -32,7 +35,7 @@ class SecureEmbedBrowserTest : public content::ContentBrowserTest {
 };
 
 IN_PROC_BROWSER_TEST_F(SecureEmbedBrowserTest, EmbedTagCreatesPlugin) {
-  // TODO: add expectations of the creation of SecureEmbedHost and other browser
+  // TODO(secure-embed): add expectations of the creation of SecureEmbedHost and other browser
   // side objects.
 }
 

--- a/components/secure_embed/browser/secure_embed_browsertest.cc
+++ b/components/secure_embed/browser/secure_embed_browsertest.cc
@@ -14,7 +14,7 @@ namespace content_capture {
 static constexpr char kTestUrl[] = "/secure_embed/embed_tag.html";
 
 // TODO(secure-embed): This needs to be in //chrome/test where a plugin is
-// is instantiated by the embedder via ContentRenderClient. ContentBrowserTest
+// instantiated by the embedder via ContentRenderClient. ContentBrowserTest
 // uses content shell and does not override ContentRenderClient.
 class SecureEmbedBrowserTest : public content::ContentBrowserTest {
  public:

--- a/components/secure_embed/buildflags/BUILD.gn
+++ b/components/secure_embed/buildflags/BUILD.gn
@@ -1,0 +1,16 @@
+# Copyright 2025 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/buildflag_header.gni")
+import("//components/secure_embed/buildflags/buildflags.gni")
+
+# This file is in a separate directory so all targets in the build can refer to
+# the buildflag header to get the necessary preprocessor defines without
+# bringing in all of secure_embed. Other targets can depend on this target
+# regardless of whether secure_embed are enabled.
+
+buildflag_header("buildflags") {
+  header = "buildflags.h"
+  flags = [ "ENABLE_SECURE_EMBED=$enable_secure_embed" ]
+}

--- a/components/secure_embed/buildflags/buildflags.gni
+++ b/components/secure_embed/buildflags/buildflags.gni
@@ -1,0 +1,10 @@
+# Copyright 2025 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/config/cast.gni")
+import("//build/config/chrome_build.gni")
+
+declare_args() {
+  enable_secure_embed = is_linux || is_mac || is_win || is_chromeos
+}

--- a/components/secure_embed/common/BUILD.gn
+++ b/components/secure_embed/common/BUILD.gn
@@ -1,0 +1,11 @@
+# Copyright 2025 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//components/secure_embed/buildflags/buildflags.gni")
+
+assert(enable_secure_embed)
+
+source_set("constants") {
+  sources = [ "constants.h" ] 
+}

--- a/components/secure_embed/common/constants.h
+++ b/components/secure_embed/common/constants.h
@@ -1,0 +1,16 @@
+// Copyright 2025 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COMPONENTS_SECURE_EMBED_COMMON_CONSTANTS_H_
+#define COMPONENTS_SECURE_EMBED_COMMON_CONSTANTS_H_
+
+namespace secure_embed {
+
+// MIME type of the internal secure-embed plugin.
+inline constexpr char kInternalPluginMimeType[] =
+    "application/x-google-chrome-secure-embed";
+
+}  // namespace secure_embed
+
+#endif  // COMPONENTS_SECURE_EMBED_COMMON_CONSTANTS_H_

--- a/components/secure_embed/renderer/BUILD.gn
+++ b/components/secure_embed/renderer/BUILD.gn
@@ -1,0 +1,21 @@
+# Copyright 2025 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//components/secure_embed/buildflags/buildflags.gni")
+
+assert(enable_secure_embed)
+
+component("renderer") {
+  public = [
+    "create_plugin.h"
+  ]
+
+  sources = [
+    "create_plugin.cc"
+  ]
+
+  deps = [
+    "//third_party/blink/public:blink",
+  ]
+}

--- a/components/secure_embed/renderer/create_plugin.cc
+++ b/components/secure_embed/renderer/create_plugin.cc
@@ -1,0 +1,23 @@
+// Copyright 2025 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "components/secure_embed/renderer/create_plugin.h"
+
+#include "base/logging.h"
+#include "components/secure_embed/common/constants.h"
+#include "third_party/blink/public/web/web_plugin_params.h"
+
+namespace secure_embed {
+
+bool MayCreatePlugin(
+    content::RenderFrame* render_frame,
+    const blink::WebPluginParams& params,
+    blink::WebPlugin** plugin) {
+  if (params.mime_type == secure_embed::kInternalPluginMimeType) {
+    return true;
+  }
+  return false;
+}
+
+}  // namespace secure_embed

--- a/components/secure_embed/renderer/create_plugin.cc
+++ b/components/secure_embed/renderer/create_plugin.cc
@@ -4,7 +4,6 @@
 
 #include "components/secure_embed/renderer/create_plugin.h"
 
-#include "base/logging.h"
 #include "components/secure_embed/common/constants.h"
 #include "third_party/blink/public/web/web_plugin_params.h"
 

--- a/components/secure_embed/renderer/create_plugin.h
+++ b/components/secure_embed/renderer/create_plugin.h
@@ -16,6 +16,7 @@ class RenderFrame;
 
 namespace secure_embed {
 
+// Returns true if a SecureEmbedWebPlugin is created.
 bool MayCreatePlugin(
     content::RenderFrame* render_frame,
     const blink::WebPluginParams& params,

--- a/components/secure_embed/renderer/create_plugin.h
+++ b/components/secure_embed/renderer/create_plugin.h
@@ -1,0 +1,26 @@
+// Copyright 2025 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COMPONENTS_SECURE_EMBED_RENDERER_CREATE_PLUGIN_H_
+#define COMPONENTS_SECURE_EMBED_RENDERER_CREATE_PLUGIN_H_
+
+namespace blink {
+class WebPlugin;
+struct WebPluginParams;
+}  // namespace blink
+
+namespace content {
+class RenderFrame;
+}  // namespace content
+
+namespace secure_embed {
+
+bool MayCreatePlugin(
+    content::RenderFrame* render_frame,
+    const blink::WebPluginParams& params,
+    blink::WebPlugin** plugin);
+
+}  // namespace secure_embed
+
+#endif // COMPONENTS_SECURE_EMBED_RENDERER_CREATE_PLUGIN_H_

--- a/components/test/data/secure_embed/embed_tag.html
+++ b/components/test/data/secure_embed/embed_tag.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-<embed type="application/x-google-secure-embed" />
+<embed type="application/x-google-chrome-secure-embed" />
 </body>
 </html>


### PR DESCRIPTION
* Add constant `secure_embed::kInternalPluginMimeType`.
* Add `secure_embed::MayCreatePlugin()` that will handle plugin creation for secure-embed's MIME type.
* Add buildflags. A target can depend on `//components/secure_embed/buildflags` and then use macro `#if BUILDFLAG(ENABLE_SECURE_EMBED)` in code.