### PR TITLE
Add secure_embed.mojom

### DIFF
--- a/chrome/browser/BUILD.gn
+++ b/chrome/browser/BUILD.gn
@@ -24,6 +24,7 @@ import("//components/lens/features.gni")
 import("//components/offline_pages/buildflags/features.gni")
 import("//components/optimization_guide/features.gni")
 import("//components/os_crypt/sync/features.gni")
+import("//components/secure_embed/buildflags/buildflags.gni")
 import("//components/services/on_device_translation/buildflags/features.gni")
 import("//components/spellcheck/spellcheck_build_features.gni")
 import("//content/public/common/features.gni")
@@ -8129,6 +8130,12 @@ static_library("browser") {
       "rlz/chrome_rlz_tracker_delegate.h",
       "rlz/chrome_rlz_tracker_web_contents_observer.cc",
       "rlz/chrome_rlz_tracker_web_contents_observer.h",
+    ]
+  }
+
+  if (enable_secure_embed) {
+    deps += [
+      "//components/secure_embed/browser",
     ]
   }
 

--- a/chrome/browser/chrome_content_browser_client_receiver_bindings.cc
+++ b/chrome/browser/chrome_content_browser_client_receiver_bindings.cc
@@ -38,6 +38,7 @@
 #include "components/safe_browsing/buildflags.h"
 #include "components/safe_browsing/content/browser/mojo_safe_browsing_impl.h"
 #include "components/safe_browsing/core/common/features.h"
+#include "components/secure_embed/buildflags/buildflags.h"
 #include "components/security_interstitials/content/security_interstitial_tab_helper.h"
 #include "components/spellcheck/spellcheck_buildflags.h"
 #include "components/subresource_filter/content/browser/content_subresource_filter_throttle_manager.h"
@@ -129,6 +130,10 @@
 
 #if BUILDFLAG(ENABLE_OFFLINE_PAGES)
 #include "chrome/browser/offline_pages/offline_page_tab_helper.h"
+#endif
+
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+#include "components/secure_embed/browser/secure_embed_host.h"
 #endif
 
 namespace {
@@ -564,6 +569,17 @@ void ChromeContentBrowserClient::
           },
           &render_frame_host));
 #endif  //  !BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+  // TODO(secure-embed): restrict access to SecureEmbedHost. Maybe move to
+  // PopulateChromeWebUIFrameBindersPartsDesktop().
+  associated_registry.AddInterface<secure_embed::mojom::SecureEmbedHost>(
+    base::BindRepeating(
+      [](content::RenderFrameHost* render_frame_host,
+         mojo::PendingAssociatedReceiver<
+          secure_embed::mojom::SecureEmbedHost> receiver) {
+        secure_embed::SecureEmbedHost::BindSecureEmbedHost(render_frame_host, std::move(receiver));
+      }, &render_frame_host));
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
 #if BUILDFLAG(ENABLE_PRINTING)
   associated_registry.AddInterface<printing::mojom::PrintManagerHost>(
       base::BindRepeating(

--- a/chrome/renderer/chrome_content_renderer_client.cc
+++ b/chrome/renderer/chrome_content_renderer_client.cc
@@ -898,7 +898,7 @@ bool ChromeContentRendererClient::OverrideCreatePlugin(
 #endif
 
 #if BUILDFLAG(ENABLE_SECURE_EMBED)
-  if (secure_embed::MayCreatePlugin(render_frame, params, plugin)) {
+  if (secure_embed::MaybeCreatePlugin(render_frame, params, plugin)) {
     return true;
   }
 #endif

--- a/components/secure_embed/browser/BUILD.gn
+++ b/components/secure_embed/browser/BUILD.gn
@@ -16,3 +16,17 @@ source_set("browser_tests") {
     "//content/test:test_support",
   ]
 }
+
+component("browser") {
+  public = [
+    "secure_embed_host.h",
+  ]
+
+  sources = [
+    "secure_embed_host.cc",
+  ]
+
+  public_deps = [
+    "//components/secure_embed/common:mojom"
+  ]
+}

--- a/components/secure_embed/browser/secure_embed_host.cc
+++ b/components/secure_embed/browser/secure_embed_host.cc
@@ -1,0 +1,18 @@
+// Copyright 2025 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "components/secure_embed/browser/secure_embed_host.h"
+
+#include "base/logging.h"
+
+namespace secure_embed {
+
+void SecureEmbedHost::BindSecureEmbedHost(
+  content::RenderFrameHost* render_frame_host,
+         mojo::PendingAssociatedReceiver<
+          secure_embed::mojom::SecureEmbedHost> receiver) {
+  LOG(ERROR) << "BindSecureEmbedHost() called";
+}
+
+}  // namespace secure_embed

--- a/components/secure_embed/browser/secure_embed_host.h
+++ b/components/secure_embed/browser/secure_embed_host.h
@@ -1,0 +1,28 @@
+// Copyright 2025 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COMPONENTS_SECURE_EMBED_BROWSER_SECURE_EMBED_HOST_H_
+#define COMPONENTS_SECURE_EMBED_BROWSER_SECURE_EMBED_HOST_H_
+
+#include "mojo/public/cpp/bindings/pending_associated_receiver.h"
+#include "components/secure_embed/common/secure_embed.mojom.h"
+
+namespace content {
+class RenderFrameHost;
+}  // namespace content
+
+namespace secure_embed {
+
+class SecureEmbedHost {
+ public:
+  static void BindSecureEmbedHost(
+    content::RenderFrameHost* render_frame_host,
+         mojo::PendingAssociatedReceiver<
+          secure_embed::mojom::SecureEmbedHost> receiver
+  );
+};
+
+}  // namespace secure_embed
+
+#endif  // COMPONENTS_SECURE_EMBED_BROWSER_SECURE_EMBED_HOST_H_

--- a/components/secure_embed/common/BUILD.gn
+++ b/components/secure_embed/common/BUILD.gn
@@ -3,9 +3,16 @@
 # found in the LICENSE file.
 
 import("//components/secure_embed/buildflags/buildflags.gni")
+import("//mojo/public/tools/bindings/mojom.gni")
 
 assert(enable_secure_embed)
 
 source_set("constants") {
   sources = [ "constants.h" ] 
+}
+
+mojom("mojom") {
+  disable_variants = true
+
+  sources = [ "secure_embed.mojom" ]
 }

--- a/components/secure_embed/common/secure_embed.mojom
+++ b/components/secure_embed/common/secure_embed.mojom
@@ -1,0 +1,15 @@
+// Copyright 2025 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+module secure_embed.mojom;
+
+// Implemented in Renderer by SecureEmbedWebPlugin.
+interface SecureEmbed {
+
+};
+
+// Implemented by Browser. Available on RenderFrameHost.
+interface SecureEmbedHost {
+  SetSecureEmbedRemote(pending_remote<SecureEmbed> remote);
+};

--- a/components/secure_embed/renderer/create_plugin.cc
+++ b/components/secure_embed/renderer/create_plugin.cc
@@ -5,15 +5,21 @@
 #include "components/secure_embed/renderer/create_plugin.h"
 
 #include "components/secure_embed/common/constants.h"
+#include "components/secure_embed/common/secure_embed.mojom.h"
+#include "content/public/renderer/render_frame.h"
+#include "mojo/public/cpp/bindings/associated_remote.h"
+#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
 #include "third_party/blink/public/web/web_plugin_params.h"
 
 namespace secure_embed {
 
-bool MayCreatePlugin(
+bool MaybeCreatePlugin(
     content::RenderFrame* render_frame,
     const blink::WebPluginParams& params,
     blink::WebPlugin** plugin) {
   if (params.mime_type == secure_embed::kInternalPluginMimeType) {
+    mojo::AssociatedRemote<secure_embed::mojom::SecureEmbedHost> secure_embed_host;
+    render_frame->GetRemoteAssociatedInterfaces()->GetInterface(&secure_embed_host);
     return true;
   }
   return false;

--- a/components/secure_embed/renderer/create_plugin.h
+++ b/components/secure_embed/renderer/create_plugin.h
@@ -17,7 +17,7 @@ class RenderFrame;
 namespace secure_embed {
 
 // Returns true if a SecureEmbedWebPlugin is created.
-bool MayCreatePlugin(
+bool MaybeCreatePlugin(
     content::RenderFrame* render_frame,
     const blink::WebPluginParams& params,
     blink::WebPlugin** plugin);


### PR DESCRIPTION
* Adds `secure_embed.mojom` that has `SecureEmbedHost` and `SecureEmbed` interface.
* Connects to RFH's `SecureEmbedHost` when the renderer side `MaybeCreatePlugin()` is called.
* Adds `SecureEmbedHost` class. The static method `SecureEmbedHost::BindSecureEmbedHost()` handles the connection.