### PR TITLE
Add skeleton SecureEmbedWebPlugin

### DIFF
--- a/chrome/browser/BUILD.gn
+++ b/chrome/browser/BUILD.gn
@@ -8134,9 +8134,7 @@ static_library("browser") {
   }
 
   if (enable_secure_embed) {
-    deps += [
-      "//components/secure_embed/browser",
-    ]
+    deps += [ "//components/secure_embed/browser" ]
   }
 
   if (enable_service_discovery) {

--- a/chrome/browser/chrome_content_browser_client_receiver_bindings.cc
+++ b/chrome/browser/chrome_content_browser_client_receiver_bindings.cc
@@ -573,12 +573,14 @@ void ChromeContentBrowserClient::
   // TODO(secure-embed): restrict access to SecureEmbedHost. Maybe move to
   // PopulateChromeWebUIFrameBindersPartsDesktop().
   associated_registry.AddInterface<secure_embed::mojom::SecureEmbedHost>(
-    base::BindRepeating(
-      [](content::RenderFrameHost* render_frame_host,
-         mojo::PendingAssociatedReceiver<
-          secure_embed::mojom::SecureEmbedHost> receiver) {
-        secure_embed::SecureEmbedHost::BindSecureEmbedHost(render_frame_host, std::move(receiver));
-      }, &render_frame_host));
+      base::BindRepeating(
+          [](content::RenderFrameHost* render_frame_host,
+             mojo::PendingAssociatedReceiver<
+                 secure_embed::mojom::SecureEmbedHost> receiver) {
+            secure_embed::SecureEmbedHost::BindSecureEmbedHost(
+                render_frame_host, std::move(receiver));
+          },
+          &render_frame_host));
 #endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
 #if BUILDFLAG(ENABLE_PRINTING)
   associated_registry.AddInterface<printing::mojom::PrintManagerHost>(

--- a/components/secure_embed/browser/BUILD.gn
+++ b/components/secure_embed/browser/BUILD.gn
@@ -18,15 +18,9 @@ source_set("browser_tests") {
 }
 
 component("browser") {
-  public = [
-    "secure_embed_host.h",
-  ]
+  public = [ "secure_embed_host.h" ]
 
-  sources = [
-    "secure_embed_host.cc",
-  ]
+  sources = [ "secure_embed_host.cc" ]
 
-  public_deps = [
-    "//components/secure_embed/common:mojom"
-  ]
+  public_deps = [ "//components/secure_embed/common:mojom" ]
 }

--- a/components/secure_embed/browser/secure_embed_host.cc
+++ b/components/secure_embed/browser/secure_embed_host.cc
@@ -9,9 +9,9 @@
 namespace secure_embed {
 
 void SecureEmbedHost::BindSecureEmbedHost(
-  content::RenderFrameHost* render_frame_host,
-         mojo::PendingAssociatedReceiver<
-          secure_embed::mojom::SecureEmbedHost> receiver) {
+    content::RenderFrameHost* render_frame_host,
+    mojo::PendingAssociatedReceiver<secure_embed::mojom::SecureEmbedHost>
+        receiver) {
   LOG(ERROR) << "BindSecureEmbedHost() called";
 }
 

--- a/components/secure_embed/browser/secure_embed_host.h
+++ b/components/secure_embed/browser/secure_embed_host.h
@@ -5,8 +5,8 @@
 #ifndef COMPONENTS_SECURE_EMBED_BROWSER_SECURE_EMBED_HOST_H_
 #define COMPONENTS_SECURE_EMBED_BROWSER_SECURE_EMBED_HOST_H_
 
-#include "mojo/public/cpp/bindings/pending_associated_receiver.h"
 #include "components/secure_embed/common/secure_embed.mojom.h"
+#include "mojo/public/cpp/bindings/pending_associated_receiver.h"
 
 namespace content {
 class RenderFrameHost;
@@ -17,10 +17,9 @@ namespace secure_embed {
 class SecureEmbedHost {
  public:
   static void BindSecureEmbedHost(
-    content::RenderFrameHost* render_frame_host,
-         mojo::PendingAssociatedReceiver<
-          secure_embed::mojom::SecureEmbedHost> receiver
-  );
+      content::RenderFrameHost* render_frame_host,
+      mojo::PendingAssociatedReceiver<secure_embed::mojom::SecureEmbedHost>
+          receiver);
 };
 
 }  // namespace secure_embed

--- a/components/secure_embed/common/BUILD.gn
+++ b/components/secure_embed/common/BUILD.gn
@@ -8,7 +8,7 @@ import("//mojo/public/tools/bindings/mojom.gni")
 assert(enable_secure_embed)
 
 source_set("constants") {
-  sources = [ "constants.h" ] 
+  sources = [ "constants.h" ]
 }
 
 mojom("mojom") {

--- a/components/secure_embed/renderer/BUILD.gn
+++ b/components/secure_embed/renderer/BUILD.gn
@@ -7,15 +7,13 @@ import("//components/secure_embed/buildflags/buildflags.gni")
 assert(enable_secure_embed)
 
 component("renderer") {
-  public = [
-    "create_plugin.h"
-  ]
+  public = [ "create_plugin.h" ]
 
   sources = [
-    "create_plugin.cc"
+    "create_plugin.cc",
+    "secure_embed_web_plugin.cc",
+    "secure_embed_web_plugin.h",
   ]
 
-  deps = [
-    "//third_party/blink/public:blink",
-  ]
+  deps = [ "//third_party/blink/public:blink" ]
 }

--- a/components/secure_embed/renderer/create_plugin.cc
+++ b/components/secure_embed/renderer/create_plugin.cc
@@ -5,21 +5,17 @@
 #include "components/secure_embed/renderer/create_plugin.h"
 
 #include "components/secure_embed/common/constants.h"
-#include "components/secure_embed/common/secure_embed.mojom.h"
-#include "content/public/renderer/render_frame.h"
+#include "components/secure_embed/renderer/secure_embed_web_plugin.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
-#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
 #include "third_party/blink/public/web/web_plugin_params.h"
 
 namespace secure_embed {
 
-bool MaybeCreatePlugin(
-    content::RenderFrame* render_frame,
-    const blink::WebPluginParams& params,
-    blink::WebPlugin** plugin) {
-  if (params.mime_type == secure_embed::kInternalPluginMimeType) {
-    mojo::AssociatedRemote<secure_embed::mojom::SecureEmbedHost> secure_embed_host;
-    render_frame->GetRemoteAssociatedInterfaces()->GetInterface(&secure_embed_host);
+bool MaybeCreatePlugin(content::RenderFrame* render_frame,
+                       const blink::WebPluginParams& params,
+                       blink::WebPlugin** plugin) {
+  if (params.mime_type == kInternalPluginMimeType) {
+    *plugin = SecureEmbedWebPlugin::Create(render_frame, params);
     return true;
   }
   return false;

--- a/components/secure_embed/renderer/create_plugin.h
+++ b/components/secure_embed/renderer/create_plugin.h
@@ -17,10 +17,9 @@ class RenderFrame;
 namespace secure_embed {
 
 // Returns true if a SecureEmbedWebPlugin is created.
-bool MaybeCreatePlugin(
-    content::RenderFrame* render_frame,
-    const blink::WebPluginParams& params,
-    blink::WebPlugin** plugin);
+bool MaybeCreatePlugin(content::RenderFrame* render_frame,
+                       const blink::WebPluginParams& params,
+                       blink::WebPlugin** plugin);
 
 }  // namespace secure_embed
 

--- a/components/secure_embed/renderer/secure_embed_web_plugin.cc
+++ b/components/secure_embed/renderer/secure_embed_web_plugin.cc
@@ -1,0 +1,101 @@
+// Copyright 2025 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "components/secure_embed/renderer/secure_embed_web_plugin.h"
+
+#include "base/notimplemented.h"
+#include "cc/paint/paint_canvas.h"
+#include "cc/paint/paint_flags.h"
+#include "content/public/renderer/render_frame.h"
+#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
+#include "third_party/blink/public/common/input/web_coalesced_input_event.h"
+#include "third_party/blink/public/platform/web_input_event_result.h"
+#include "third_party/blink/public/platform/web_url_error.h"
+#include "third_party/blink/public/web/web_local_frame.h"
+#include "third_party/blink/public/web/web_plugin_container.h"
+#include "third_party/blink/public/web/web_plugin_params.h"
+#include "third_party/skia/include/core/SkColor.h"
+#include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/geometry/skia_conversions.h"
+#include "v8/include/v8-local-handle.h"
+
+namespace secure_embed {
+
+// static
+SecureEmbedWebPlugin* SecureEmbedWebPlugin::Create(
+    content::RenderFrame* render_frame,
+    const blink::WebPluginParams& params) {
+  mojo::AssociatedRemote<mojom::SecureEmbedHost> host;
+  render_frame->GetRemoteAssociatedInterfaces()->GetInterface(&host);
+  return new SecureEmbedWebPlugin(std::move(host));
+}
+
+SecureEmbedWebPlugin::SecureEmbedWebPlugin(
+    mojo::AssociatedRemote<mojom::SecureEmbedHost> host)
+    : host_(std::move(host)) {}
+
+SecureEmbedWebPlugin::~SecureEmbedWebPlugin() = default;
+
+bool SecureEmbedWebPlugin::Initialize(blink::WebPluginContainer* container) {
+  container_ = container;
+  return true;
+}
+
+void SecureEmbedWebPlugin::Destroy() {
+  delete this;
+}
+
+blink::WebPluginContainer* SecureEmbedWebPlugin::Container() const {
+  return container_;
+}
+
+v8::Local<v8::Object> SecureEmbedWebPlugin::V8ScriptableObject(
+    v8::Isolate* isolate) {
+  return v8::Local<v8::Object>();
+}
+
+void SecureEmbedWebPlugin::UpdateAllLifecyclePhases(
+    blink::DocumentUpdateReason reason) {}
+
+void SecureEmbedWebPlugin::Paint(cc::PaintCanvas* canvas,
+                                 const gfx::Rect& rect) {
+  cc::PaintFlags flags;
+  flags.setColor(SK_ColorRED);
+  canvas->drawRect(gfx::RectToSkRect(rect), flags);
+}
+
+void SecureEmbedWebPlugin::UpdateGeometry(const gfx::Rect& window_rect,
+                                          const gfx::Rect& clip_rect,
+                                          const gfx::Rect& unobscured_rect,
+                                          bool is_visible) {}
+
+void SecureEmbedWebPlugin::UpdateFocus(bool focused,
+                                       blink::mojom::FocusType focus_type) {}
+
+void SecureEmbedWebPlugin::UpdateVisibility(bool is_visible) {}
+
+blink::WebInputEventResult SecureEmbedWebPlugin::HandleInputEvent(
+    const blink::WebCoalescedInputEvent& event,
+    ui::Cursor* cursor) {
+  return blink::WebInputEventResult::kNotHandled;
+}
+
+void SecureEmbedWebPlugin::DidReceiveResponse(
+    const blink::WebURLResponse& response) {
+  NOTIMPLEMENTED();
+}
+
+void SecureEmbedWebPlugin::DidReceiveData(base::span<const char> data) {
+  NOTIMPLEMENTED();
+}
+
+void SecureEmbedWebPlugin::DidFinishLoading() {
+  NOTIMPLEMENTED();
+}
+
+void SecureEmbedWebPlugin::DidFailLoading(const blink::WebURLError& error) {
+  NOTIMPLEMENTED();
+}
+
+}  // namespace secure_embed

--- a/components/secure_embed/renderer/secure_embed_web_plugin.h
+++ b/components/secure_embed/renderer/secure_embed_web_plugin.h
@@ -1,0 +1,64 @@
+// Copyright 2025 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COMPONENTS_SECURE_EMBED_RENDERER_SECURE_EMBED_WEB_PLUGIN_H_
+#define COMPONENTS_SECURE_EMBED_RENDERER_SECURE_EMBED_WEB_PLUGIN_H_
+
+#include "base/memory/raw_ptr.h"
+#include "components/secure_embed/common/secure_embed.mojom.h"
+#include "mojo/public/cpp/bindings/associated_remote.h"
+#include "third_party/blink/public/web/web_plugin.h"
+
+namespace blink {
+struct WebPluginParams;
+class WebPluginContainer;
+}  // namespace blink
+
+namespace content {
+class RenderFrame;
+}  // namespace content
+
+namespace secure_embed {
+
+class SecureEmbedWebPlugin : public blink::WebPlugin {
+ public:
+  static SecureEmbedWebPlugin* Create(content::RenderFrame* render_frame,
+                                      const blink::WebPluginParams& params);
+
+  SecureEmbedWebPlugin(const SecureEmbedWebPlugin&) = delete;
+  SecureEmbedWebPlugin& operator=(const SecureEmbedWebPlugin&) = delete;
+  ~SecureEmbedWebPlugin() override;
+
+  // blink::WebPlugin:
+  bool Initialize(blink::WebPluginContainer* container) override;
+  void Destroy() override;
+  blink::WebPluginContainer* Container() const override;
+  v8::Local<v8::Object> V8ScriptableObject(v8::Isolate* isolate) override;
+  void UpdateAllLifecyclePhases(blink::DocumentUpdateReason reason) override;
+  void Paint(cc::PaintCanvas* canvas, const gfx::Rect& rect) override;
+  void UpdateGeometry(const gfx::Rect& window_rect,
+                      const gfx::Rect& clip_rect,
+                      const gfx::Rect& unobscured_rect,
+                      bool is_visible) override;
+  void UpdateFocus(bool focused, blink::mojom::FocusType focus_type) override;
+  void UpdateVisibility(bool is_visible) override;
+  blink::WebInputEventResult HandleInputEvent(
+      const blink::WebCoalescedInputEvent& event,
+      ui::Cursor* cursor) override;
+  void DidReceiveResponse(const blink::WebURLResponse& response) override;
+  void DidReceiveData(base::span<const char> data) override;
+  void DidFinishLoading() override;
+  void DidFailLoading(const blink::WebURLError& error) override;
+
+ private:
+  explicit SecureEmbedWebPlugin(
+      mojo::AssociatedRemote<mojom::SecureEmbedHost> host);
+
+  mojo::AssociatedRemote<mojom::SecureEmbedHost> host_;
+  raw_ptr<blink::WebPluginContainer> container_ = nullptr;
+};
+
+}  // namespace secure_embed
+
+#endif  // COMPONENTS_SECURE_EMBED_RENDERER_SECURE_EMBED_WEB_PLUGIN_H_


### PR DESCRIPTION
This PR adds a skeleton implementation of `SecureEmbedWebPlugin` that fills the canvas with red color.