### PR TITLE
Enable component builds for secure_embed

### DIFF
--- a/components/secure_embed/browser/BUILD.gn
+++ b/components/secure_embed/browser/BUILD.gn
@@ -2,11 +2,29 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//components/secure_embed/buildflags/buildflags.gni")
+
+assert(enable_secure_embed)
+
+component("browser") {
+  defines = [ "IS_SECURE_EMBED_IMPL" ]
+
+  public = [ "secure_embed_host.h" ]
+
+  sources = [
+    "secure_embed_host.cc",
+    "secure_embed_host.h",
+  ]
+
+  public_deps = [ "//components/secure_embed/common:mojom" ]
+}
+
 source_set("browser_tests") {
   testonly = true
-  sources = [ "secure_embed_browsertest.cc" ]
 
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+  sources = [ "secure_embed_browsertest.cc" ]
 
   public_deps = [
     "//base/test:test_support",
@@ -15,12 +33,4 @@ source_set("browser_tests") {
     "//content/test:browsertest_support",
     "//content/test:test_support",
   ]
-}
-
-component("browser") {
-  public = [ "secure_embed_host.h" ]
-
-  sources = [ "secure_embed_host.cc" ]
-
-  public_deps = [ "//components/secure_embed/common:mojom" ]
 }

--- a/components/secure_embed/browser/secure_embed_host.h
+++ b/components/secure_embed/browser/secure_embed_host.h
@@ -5,6 +5,7 @@
 #ifndef COMPONENTS_SECURE_EMBED_BROWSER_SECURE_EMBED_HOST_H_
 #define COMPONENTS_SECURE_EMBED_BROWSER_SECURE_EMBED_HOST_H_
 
+#include "base/component_export.h"
 #include "components/secure_embed/common/secure_embed.mojom.h"
 #include "mojo/public/cpp/bindings/pending_associated_receiver.h"
 
@@ -14,7 +15,7 @@ class RenderFrameHost;
 
 namespace secure_embed {
 
-class SecureEmbedHost {
+class COMPONENT_EXPORT(SECURE_EMBED) SecureEmbedHost {
  public:
   static void BindSecureEmbedHost(
       content::RenderFrameHost* render_frame_host,

--- a/components/secure_embed/renderer/BUILD.gn
+++ b/components/secure_embed/renderer/BUILD.gn
@@ -7,13 +7,18 @@ import("//components/secure_embed/buildflags/buildflags.gni")
 assert(enable_secure_embed)
 
 component("renderer") {
+  defines = [ "IS_SECURE_EMBED_IMPL" ]
+
   public = [ "create_plugin.h" ]
 
   sources = [
     "create_plugin.cc",
+    "create_plugin.h",
     "secure_embed_web_plugin.cc",
     "secure_embed_web_plugin.h",
   ]
 
   deps = [ "//third_party/blink/public:blink" ]
+
+  public_deps = [ "//components/secure_embed/common:mojom" ]
 }

--- a/components/secure_embed/renderer/create_plugin.h
+++ b/components/secure_embed/renderer/create_plugin.h
@@ -5,6 +5,8 @@
 #ifndef COMPONENTS_SECURE_EMBED_RENDERER_CREATE_PLUGIN_H_
 #define COMPONENTS_SECURE_EMBED_RENDERER_CREATE_PLUGIN_H_
 
+#include "base/component_export.h"
+
 namespace blink {
 class WebPlugin;
 struct WebPluginParams;
@@ -17,6 +19,7 @@ class RenderFrame;
 namespace secure_embed {
 
 // Returns true if a SecureEmbedWebPlugin is created.
+COMPONENT_EXPORT(SECURE_EMBED)
 bool MaybeCreatePlugin(content::RenderFrame* render_frame,
                        const blink::WebPluginParams& params,
                        blink::WebPlugin** plugin);


### PR DESCRIPTION
To support both component and non-component builds, the change leverages
base/component_export.h's infrastructure to conditionally export symbols
when needed via COMPONENT_EXPORT.

Verified with a non-component release build and a component debug build.

Also some misc cleanup items in BUILD.gn files:

* secure_embed/browser - moved tests to bottom and added
  `assert(enable_secure_embed)`
* secure_embed/renderer - add public_deps and missing source file