### PR TITLE
Add secure_embed plugin support to content_shell

### DIFF
--- a/content/shell/BUILD.gn
+++ b/content/shell/BUILD.gn
@@ -10,6 +10,7 @@ import("//build/config/sanitizers/sanitizers.gni")
 import("//build/config/ui.gni")
 import("//build/config/win/console_app.gni")
 import("//build/config/win/manifest.gni")
+import("//components/secure_embed/buildflags/buildflags.gni")
 import("//content/public/common/features.gni")
 import("//device/vr/buildflags/buildflags.gni")
 import("//gpu/vulkan/features.gni")
@@ -392,6 +393,13 @@ static_library("content_shell_lib") {
     sources += [
       "browser/shell_plugin_service_filter.cc",
       "browser/shell_plugin_service_filter.h",
+    ]
+  }
+
+  if (enable_secure_embed) {
+    deps += [
+      "//components/secure_embed/browser",
+      "//components/secure_embed/renderer",
     ]
   }
 

--- a/content/shell/browser/shell_content_browser_client.cc
+++ b/content/shell/browser/shell_content_browser_client.cc
@@ -47,6 +47,7 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service_factory.h"
 #include "components/prefs/scoped_user_pref_update.h"
+#include "components/secure_embed/buildflags/buildflags.h"
 #include "components/variations/platform_field_trials.h"
 #include "components/variations/pref_names.h"
 #include "components/variations/service/safe_seed_manager.h"
@@ -141,6 +142,11 @@
 #include "media/mojo/mojom/media_foundation_preferences.mojom.h"
 #include "media/mojo/services/media_foundation_preferences.h"
 #endif  // BUILDFLAG(IS_WIN)
+
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+#include "components/secure_embed/browser/secure_embed_host.h"
+#include "third_party/blink/public/common/associated_interfaces/associated_interface_registry.h"
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
 
 namespace content {
 
@@ -674,6 +680,23 @@ void ShellContentBrowserClient::RegisterBrowserInterfaceBindersForFrame(
   map->Add<media::mojom::MediaFoundationPreferences>(
       &BindMediaFoundationPreferences);
 #endif  // BUILDFLAG(IS_WIN)
+}
+
+void ShellContentBrowserClient::
+    RegisterAssociatedInterfaceBindersForRenderFrameHost(
+        RenderFrameHost& render_frame_host,
+        blink::AssociatedInterfaceRegistry& associated_registry) {
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+  associated_registry.AddInterface<secure_embed::mojom::SecureEmbedHost>(
+      base::BindRepeating(
+          [](content::RenderFrameHost* render_frame_host,
+             mojo::PendingAssociatedReceiver<
+                 secure_embed::mojom::SecureEmbedHost> receiver) {
+            secure_embed::SecureEmbedHost::BindSecureEmbedHost(
+                render_frame_host, std::move(receiver));
+          },
+          &render_frame_host));
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
 }
 
 void ShellContentBrowserClient::OpenURL(

--- a/content/shell/browser/shell_content_browser_client.h
+++ b/content/shell/browser/shell_content_browser_client.h
@@ -122,6 +122,9 @@ class ShellContentBrowserClient : public ContentBrowserClient {
   void RegisterBrowserInterfaceBindersForFrame(
       RenderFrameHost* render_frame_host,
       mojo::BinderMapWithContext<RenderFrameHost*>* map) override;
+  void RegisterAssociatedInterfaceBindersForRenderFrameHost(
+      RenderFrameHost& render_frame_host,
+      blink::AssociatedInterfaceRegistry& associated_registry) override;
   void OpenURL(SiteInstance* site_instance,
                const OpenURLParams& params,
                base::OnceCallback<void(WebContents*)> callback) override;

--- a/content/shell/renderer/shell_content_renderer_client.cc
+++ b/content/shell/renderer/shell_content_renderer_client.cc
@@ -19,6 +19,7 @@
 #include "base/types/pass_key.h"
 #include "components/cdm/renderer/external_clear_key_key_system_info.h"
 #include "components/network_hints/renderer/web_prescient_networking_impl.h"
+#include "components/secure_embed/buildflags/buildflags.h"
 #include "components/web_cache/renderer/web_cache_impl.h"
 #include "content/public/common/content_switches.h"
 #include "content/public/common/pseudonymization_util.h"
@@ -49,6 +50,10 @@
 #include "base/feature_list.h"
 #include "media/base/media_switches.h"
 #endif
+
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+#include "components/secure_embed/renderer/create_plugin.h"
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
 
 #if (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS)) && \
     (defined(ARCH_CPU_X86_64) || defined(ARCH_CPU_ARM64))
@@ -354,6 +359,18 @@ std::unique_ptr<blink::URLLoaderThrottleProvider>
 ShellContentRendererClient::CreateURLLoaderThrottleProvider(
     blink::URLLoaderThrottleProviderType provider_type) {
   return std::make_unique<ShellContentRendererUrlLoaderThrottleProvider>();
+}
+
+bool ShellContentRendererClient::OverrideCreatePlugin(
+    content::RenderFrame* render_frame,
+    const blink::WebPluginParams& params,
+    blink::WebPlugin** plugin) {
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+  if (secure_embed::MaybeCreatePlugin(render_frame, params, plugin)) {
+    return true;
+  }
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
+  return false;
 }
 
 #if BUILDFLAG(ENABLE_MOJO_CDM)

--- a/content/shell/renderer/shell_content_renderer_client.h
+++ b/content/shell/renderer/shell_content_renderer_client.h
@@ -56,6 +56,10 @@ class ShellContentRendererClient : public ContentRendererClient {
   CreateURLLoaderThrottleProvider(
       blink::URLLoaderThrottleProviderType provider_type) override;
 
+  bool OverrideCreatePlugin(content::RenderFrame* render_frame,
+                            const blink::WebPluginParams& params,
+                            blink::WebPlugin** plugin) override;
+
 #if BUILDFLAG(ENABLE_MOJO_CDM)
   std::unique_ptr<media::KeySystemSupportRegistration> GetSupportedKeySystems(
       content::RenderFrame* render_frame,


### PR DESCRIPTION
This CL integrates the secure_embed plugin into content_shell, mirroring
the implementation in /chrome.