### PR TITLE
Add abstract class CrossProcessFrameConnectorBase to virtualize CPFC

### DIFF
--- a/content/browser/BUILD.gn
+++ b/content/browser/BUILD.gn
@@ -1806,6 +1806,7 @@ source_set("browser") {
     "renderer_host/cookie_utils.h",
     "renderer_host/cross_process_frame_connector.cc",
     "renderer_host/cross_process_frame_connector.h",
+    "renderer_host/cross_process_frame_connector_base.h",
     "renderer_host/data_transfer_util.cc",
     "renderer_host/data_transfer_util.h",
     "renderer_host/debug_urls.cc",

--- a/content/browser/renderer_host/cross_process_frame_connector.cc
+++ b/content/browser/renderer_host/cross_process_frame_connector.cc
@@ -244,6 +244,26 @@ CrossProcessFrameConnector::GetRootViewInput() {
   return GetRootRenderWidgetHostView();
 }
 
+double CrossProcessFrameConnector::GetCssZoomFactor() const {
+  return last_received_css_zoom_factor_;
+}
+
+const gfx::Size& CrossProcessFrameConnector::GetLocalFrameSizeInPixels() const {
+  return local_frame_size_in_pixels_;
+}
+
+const gfx::Size& CrossProcessFrameConnector::GetLocalFrameSizeInDip() const {
+  return local_frame_size_in_dip_;
+}
+
+const gfx::Rect& CrossProcessFrameConnector::GetRectInParentViewInDip() const {
+  return rect_in_parent_view_in_dip_;
+}
+
+uint32_t CrossProcessFrameConnector::GetCaptureSequenceNumber() const {
+  return capture_sequence_number_;
+}
+
 void CrossProcessFrameConnector::UpdateCursor(const ui::Cursor& cursor) {
   RenderWidgetHostViewBase* root_view = GetRootRenderWidgetHostView();
   // UpdateCursor messages are ignored if the root view does not support
@@ -290,6 +310,20 @@ void CrossProcessFrameConnector::UnlockPointer() {
     root_view->UnlockPointer();
 }
 
+const blink::mojom::ViewportIntersectionState&
+CrossProcessFrameConnector::GetIntersectionState() const {
+  return intersection_state_;
+}
+
+const viz::LocalSurfaceId& CrossProcessFrameConnector::GetLocalSurfaceId()
+    const {
+  return local_surface_id_;
+}
+
+const display::ScreenInfos& CrossProcessFrameConnector::GetScreenInfos() const {
+  return screen_infos_;
+}
+
 void CrossProcessFrameConnector::OnSynchronizeVisualProperties(
     const blink::FrameVisualProperties& visual_properties) {
   TRACE_EVENT_WITH_FLOW2(
@@ -304,7 +338,8 @@ void CrossProcessFrameConnector::OnSynchronizeVisualProperties(
   // changed, then the viz::LocalSurfaceId must also change.
   if ((last_received_local_frame_size_ != visual_properties.local_frame_size ||
        screen_infos_.current() != visual_properties.screen_infos.current() ||
-       capture_sequence_number() != visual_properties.capture_sequence_number ||
+       GetCaptureSequenceNumber() !=
+           visual_properties.capture_sequence_number ||
        last_received_zoom_level_ != visual_properties.zoom_level ||
        last_received_css_zoom_factor_ != visual_properties.css_zoom_factor) &&
       local_surface_id_ == visual_properties.local_surface_id) {
@@ -473,6 +508,10 @@ void CrossProcessFrameConnector::DidUpdateVisualProperties(
   frame_proxy_in_parent_renderer_->DidUpdateVisualProperties(metadata);
 }
 
+bool CrossProcessFrameConnector::HasSize() const {
+  return has_size_;
+}
+
 void CrossProcessFrameConnector::SetVisibilityForChildViews(
     bool visible) const {
   current_child_frame_host()->SetVisibilityForChildViews(visible);
@@ -619,7 +658,7 @@ void CrossProcessFrameConnector::DelegateWasShown() {
 
 bool CrossProcessFrameConnector::IsVisible() {
   if (visibility_ == blink::mojom::FrameVisibility::kNotRendered ||
-      intersection_state().viewport_intersection.IsEmpty()) {
+      GetIntersectionState().viewport_intersection.IsEmpty()) {
     return false;
   }
 

--- a/content/browser/renderer_host/cross_process_frame_connector.h
+++ b/content/browser/renderer_host/cross_process_frame_connector.h
@@ -11,9 +11,7 @@
 #include "base/memory/raw_ptr.h"
 #include "cc/input/touch_action.h"
 #include "components/input/child_frame_input_helper.h"
-#include "components/viz/common/quads/compositor_frame.h"
-#include "components/viz/common/surfaces/local_surface_id.h"
-#include "components/viz/common/surfaces/surface_id.h"
+#include "content/browser/renderer_host/cross_process_frame_connector_base.h"
 #include "content/common/content_export.h"
 #include "content/public/browser/visibility.h"
 #include "third_party/blink/public/common/frame/frame_visual_properties.h"
@@ -88,7 +86,7 @@ class RenderWidgetHostViewChildFrame;
 // process, SetView() is called to update to the new view.
 //
 class CONTENT_EXPORT CrossProcessFrameConnector
-    : public input::ChildFrameInputHelper::Delegate {
+    : public CrossProcessFrameConnectorBase {
  public:
   // |frame_proxy_in_parent_renderer| corresponds to A2 in the example above.
   explicit CrossProcessFrameConnector(
@@ -104,171 +102,154 @@ class CONTENT_EXPORT CrossProcessFrameConnector
   // above.
   RenderWidgetHostViewChildFrame* get_view_for_testing() { return view_; }
 
-  void SetView(RenderWidgetHostViewChildFrame* view, bool allow_paint_holding);
+  void SetView(RenderWidgetHostViewChildFrame* view,
+               bool allow_paint_holding) override;
 
   // Returns the parent RenderWidgetHostView or nullptr if it doesn't have one.
-  virtual RenderWidgetHostViewBase* GetParentRenderWidgetHostView();
+  RenderWidgetHostViewBase* GetParentRenderWidgetHostView() override;
 
   // Returns the view for the top-level frame under the same WebContents.
-  virtual RenderWidgetHostViewBase* GetRootRenderWidgetHostView();
+  RenderWidgetHostViewBase* GetRootRenderWidgetHostView() override;
 
   // Notify the frame connector that the renderer process has terminated.
-  void RenderProcessGone();
+  void RenderProcessGone() override;
 
   // Provide the SurfaceInfo to the embedder, which becomes a reference to the
   // current view's Surface that is included in higher-level compositor
   // frames. This is virtual to be overridden in tests.
-  virtual void FirstSurfaceActivation(const viz::SurfaceInfo& surface_info) {}
+  void FirstSurfaceActivation(const viz::SurfaceInfo& surface_info) override {}
 
   // Sends the given intrinsic sizing information from a sub-frame to
   // its corresponding remote frame in the parent frame's renderer.
-  void SendIntrinsicSizingInfoToParent(blink::mojom::IntrinsicSizingInfoPtr);
+  void SendIntrinsicSizingInfoToParent(
+      blink::mojom::IntrinsicSizingInfoPtr) override;
 
   // Record and apply new visual properties for the subframe. If 'propagate' is
   // true, the new properties will be sent to the subframe's renderer process.
   void SynchronizeVisualProperties(
       const blink::FrameVisualProperties& visual_properties,
-      bool propagate = true);
+      bool propagate = true) override;
 
   // ChildFrameInputHelper::Delegate implementation.
   input::RenderWidgetHostViewInput* GetParentViewInput() override;
   input::RenderWidgetHostViewInput* GetRootViewInput() override;
 
-  double css_zoom_factor() const { return last_received_css_zoom_factor_; }
+  double GetCssZoomFactor() const override;
 
   // Return the size of the CompositorFrame to use in the child renderer.
-  const gfx::Size& local_frame_size_in_pixels() const {
-    return local_frame_size_in_pixels_;
-  }
+  const gfx::Size& GetLocalFrameSizeInPixels() const override;
 
   // Return the size of the CompositorFrame to use in the child renderer in DIP.
   // This is used to set the layout size of the child renderer.
-  const gfx::Size& local_frame_size_in_dip() const {
-    return local_frame_size_in_dip_;
-  }
+  const gfx::Size& GetLocalFrameSizeInDip() const override;
 
   // Return the rect in DIP that the RenderWidgetHostViewChildFrame's content
   // will render into.
-  const gfx::Rect& rect_in_parent_view_in_dip() const {
-    return rect_in_parent_view_in_dip_;
-  }
+  const gfx::Rect& GetRectInParentViewInDip() const override;
 
   // Return the latest capture sequence number for this subframe.
-  uint32_t capture_sequence_number() const { return capture_sequence_number_; }
+  uint32_t GetCaptureSequenceNumber() const override;
 
   // Request that the platform change the mouse cursor when the mouse is
   // positioned over this view's content.
-  void UpdateCursor(const ui::Cursor& cursor);
-
-  // These values are written to logs. Do not renumber or delete existing items;
-  // add new entries to the end of the list.
-  enum class RootViewFocusState {
-    // RootView is NULL.
-    kNullView = 0,
-    // Root View is already focused.
-    kFocused = 1,
-    // Root View is not focused at TouchStart. Calls
-    // RenderWidgetHostViewChildFrame::Focus() to focus it.
-    kNotFocused = 2,
-    kMaxValue = kNotFocused
-  };
+  void UpdateCursor(const ui::Cursor& cursor) override;
 
   // Determines whether the root RenderWidgetHostView (and thus the current
   // page) has focus. We need a tri-state enum as a return variable to
   // differentiate between the cases where root view is NULL and when it's
   // actually focused/unfocused. No behaviour change expected in focus handling.
-  RootViewFocusState HasFocus();
+  RootViewFocusState HasFocus() override;
 
   // Cause the root RenderWidgetHostView to become focused.
-  void FocusRootView();
+  void FocusRootView() override;
 
   // Locks the mouse pointer, if |request_unadjusted_movement_| is true, try
   // setting the unadjusted movement mode. Returns true if mouse pointer is
   // locked.
-  blink::mojom::PointerLockResult LockPointer(bool request_unadjusted_movement);
+  blink::mojom::PointerLockResult LockPointer(
+      bool request_unadjusted_movement) override;
 
   // Change the current pointer lock to match the unadjusted movement option
   // given.
   blink::mojom::PointerLockResult ChangePointerLock(
-      bool request_unadjusted_movement);
+      bool request_unadjusted_movement) override;
 
   // Unlocks the mouse pointer if it is locked.
-  void UnlockPointer();
+  void UnlockPointer() override;
 
   // Returns the state of the frame's intersection with the top-level viewport.
-  const blink::mojom::ViewportIntersectionState& intersection_state() const {
-    return intersection_state_;
-  }
+  const blink::mojom::ViewportIntersectionState& GetIntersectionState()
+      const override;
 
   // Returns the viz::LocalSurfaceId propagated from the parent to be
   // used by this child frame.
-  const viz::LocalSurfaceId& local_surface_id() const {
-    return local_surface_id_;
-  }
+  const viz::LocalSurfaceId& GetLocalSurfaceId() const override;
 
   // Returns the ScreenInfos propagated from the parent to be used by this
   // child frame.
-  const display::ScreenInfos& screen_infos() const { return screen_infos_; }
+  const display::ScreenInfos& GetScreenInfos() const override;
 
   // Informs the parent the child will enter auto-resize mode, automatically
   // resizing itself to the provided |min_size| and |max_size| constraints.
-  void EnableAutoResize(const gfx::Size& min_size, const gfx::Size& max_size);
+  void EnableAutoResize(const gfx::Size& min_size,
+                        const gfx::Size& max_size) override;
 
   // Turns off auto-resize mode.
-  void DisableAutoResize();
+  void DisableAutoResize() override;
 
   // Determines whether the current view's content is inert, either because
   // an HTMLDialogElement is being modally displayed in a higher-level frame,
   // or because the inert attribute has been specified.
-  bool IsInert() const;
+  bool IsInert() const override;
 
   // Returns the inherited effective touch action property that should be
   // applied to any nested child RWHVCFs inside the caller RWHVCF.
-  cc::TouchAction InheritedEffectiveTouchAction() const;
+  cc::TouchAction InheritedEffectiveTouchAction() const override;
 
   // Determines whether the RenderWidgetHostViewChildFrame is hidden due to
   // a higher-level embedder being hidden. This is distinct from the
   // RenderWidgetHostImpl being hidden, which is a property set when
   // RenderWidgetHostView::Hide() is called on the current view.
-  bool IsHidden() const;
+  bool IsHidden() const override;
 
   // IsThrottled() indicates that the frame is outside of it's parent frame's
   // visible viewport, and should be render throttled.
-  bool IsThrottled() const;
+  bool IsThrottled() const override;
   // IsSubtreeThrottled() indicates that IsThrottled() is true for one of this
   // frame's ancestors, which means this frame must also be throttled.
-  bool IsSubtreeThrottled() const;
+  bool IsSubtreeThrottled() const override;
   // IsDisplayLocked() indicates that a DOM ancestor of this frame's owning
   // <iframe> element in the parent frame is currently display locked; or that
   // IsDisplayLocked() is true for one of this frame's ancestors; which means
   // this frame should be render throttled.
-  bool IsDisplayLocked() const;
+  bool IsDisplayLocked() const override;
 
   // Called by RenderWidgetHostViewChildFrame when the child frame has updated
   // its visual properties and its viz::LocalSurfaceId has changed.
-  void DidUpdateVisualProperties(const cc::RenderFrameMetadata& metadata);
+  void DidUpdateVisualProperties(
+      const cc::RenderFrameMetadata& metadata) override;
 
-  bool has_size() const { return has_size_; }
+  bool HasSize() const override;
 
   // Called by RenderWidgetHostViewChildFrame to update the visibility of any
   // nested child RWHVCFs inside it.
-  void SetVisibilityForChildViews(bool visible) const;
+  void SetVisibilityForChildViews(bool visible) const override;
 
   // Called to resize the child renderer's CompositorFrame.
   // |local_frame_size| is in pixels if zoom-for-dsf is enabled, and in DIP
   // if not.
-  void SetLocalFrameSize(const gfx::Size& local_frame_size);
+  void SetLocalFrameSize(const gfx::Size& local_frame_size) override;
 
   // Called to resize the child renderer. |rect_in_parent_view| is in physical
   // pixels.
-  void SetRectInParentView(const gfx::Rect& rect_in_parent_view);
+  void SetRectInParentView(const gfx::Rect& rect_in_parent_view) override;
 
-  void SetIsInert(bool inert);
+  void SetIsInert(bool inert) override;
 
   // Handlers for messages received from the parent frame called
   // from RenderFrameProxyHost to be sent to |view_|.
-  void OnSetInheritedEffectiveTouchAction(cc::TouchAction);
-  void OnVisibilityChanged(blink::mojom::FrameVisibility visibility);
+  void OnSetInheritedEffectiveTouchAction(cc::TouchAction) override;
+  void OnVisibilityChanged(blink::mojom::FrameVisibility visibility) override;
 
   // Exposed for tests.
   RenderWidgetHostViewBase* GetRootRenderWidgetHostViewForTesting() {
@@ -277,10 +258,11 @@ class CONTENT_EXPORT CrossProcessFrameConnector
 
   void UpdateRenderThrottlingStatus(bool is_throttled,
                                     bool subtree_throttled,
-                                    bool display_locked);
+                                    bool display_locked) override;
   void UpdateViewportIntersection(
       const blink::mojom::ViewportIntersectionState& intersection_state,
-      const std::optional<blink::FrameVisualProperties>& visual_properties);
+      const std::optional<blink::FrameVisualProperties>& visual_properties)
+      override;
 
   // These enums back crashed frame histograms - see MaybeLogCrash() and
   // MaybeLogShownCrash() below.  Please do not modify or remove existing enum
@@ -306,16 +288,16 @@ class CONTENT_EXPORT CrossProcessFrameConnector
   // Returns whether the child widget is actually visible to the user.  This is
   // different from the IsHidden override, and takes into account viewport
   // intersection as well as the visibility of the RenderFrameHostDelegate.
-  bool IsVisible();
+  bool IsVisible() override;
 
   // This function is called by the RenderFrameHostDelegate to signal that it
   // became visible. This is called after any navigations resulting from
   // visibility changes have been queued (e.g. if needs-reload was set).
-  void DelegateWasShown();
+  void DelegateWasShown() override;
 
   // Handlers for messages received from the parent frame.
   void OnSynchronizeVisualProperties(
-      const blink::FrameVisualProperties& visual_properties);
+      const blink::FrameVisualProperties& visual_properties) override;
 
   blink::mojom::FrameVisibility visibility() const { return visibility_; }
 
@@ -325,7 +307,7 @@ class CONTENT_EXPORT CrossProcessFrameConnector
   }
 
   // Returns the embedder's visibility.
-  Visibility EmbedderVisibility();
+  Visibility EmbedderVisibility() override;
 
  protected:
   friend class MockCrossProcessFrameConnector;

--- a/content/browser/renderer_host/cross_process_frame_connector_base.h
+++ b/content/browser/renderer_host/cross_process_frame_connector_base.h
@@ -1,0 +1,255 @@
+// Copyright 2025 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CONTENT_BROWSER_RENDERER_HOST_CROSS_PROCESS_FRAME_CONNECTOR_BASE_H_
+#define CONTENT_BROWSER_RENDERER_HOST_CROSS_PROCESS_FRAME_CONNECTOR_BASE_H_
+
+#include <stdint.h>
+
+#include "cc/input/touch_action.h"
+#include "components/input/child_frame_input_helper.h"
+#include "components/viz/common/surfaces/local_surface_id.h"
+#include "content/common/content_export.h"
+#include "content/public/browser/visibility.h"
+#include "third_party/blink/public/common/frame/frame_visual_properties.h"
+#include "third_party/blink/public/mojom/frame/intrinsic_sizing_info.mojom-forward.h"
+#include "third_party/blink/public/mojom/frame/lifecycle.mojom-forward.h"
+#include "third_party/blink/public/mojom/frame/viewport_intersection_state.mojom-forward.h"
+#include "third_party/blink/public/mojom/input/pointer_lock_result.mojom-shared.h"
+#include "ui/display/screen_infos.h"
+#include "ui/gfx/geometry/rect.h"
+
+namespace cc {
+class RenderFrameMetadata;
+}
+
+namespace blink {
+struct FrameVisualProperties;
+}  // namespace blink
+
+namespace ui {
+class Cursor;
+}
+
+namespace viz {
+class SurfaceInfo;
+}  // namespace viz
+
+namespace content {
+
+class RenderWidgetHostViewBase;
+class RenderWidgetHostViewChildFrame;
+
+// CrossProcessFrameConnectorBase allows CrossProcessFrameConnector and
+// SecureEmbedHost to share a common interface.
+//
+// CrossProcessFrameConnector provides the platform view abstraction for
+// RenderWidgetHostViewChildFrame allowing RWHVChildFrame to remain ignorant
+// of RenderFrameHost.
+//
+// The RenderWidgetHostView of an out-of-process child frame needs to
+// communicate with the RenderFrameProxyHost representing this frame in the
+// process of the parent frame. For example, assume you have this page:
+//
+//   -----------------
+//   | frame 1       |
+//   |  -----------  |
+//   |  | frame 2 |  |
+//   |  -----------  |
+//   -----------------
+//
+// If frames 1 and 2 are in process A and B, there are 4 hosts:
+//   A1 - RFH for frame 1 in process A
+//   B1 - RFPH for frame 1 in process B
+//   A2 - RFPH for frame 2 in process A
+//   B2 - RFH for frame 2 in process B
+//
+// B2, having a parent frame in a different process, will have a
+// RenderWidgetHostViewChildFrame. This RenderWidgetHostViewChildFrame needs
+// to communicate with A2 because the embedding frame represents the platform
+// that the child frame is rendering into -- it needs information necessary for
+// compositing child frame textures, and also can pass platform messages such as
+// view resizing. CrossProcessFrameConnector bridges between B2's
+// RenderWidgetHostViewChildFrame and A2 to allow for this communication.
+// (Note: B1 is only mentioned for completeness. It is not needed in this
+// example.)
+//
+// CrossProcessFrameConnector objects are owned by the RenderFrameProxyHost
+// in the child frame's RenderFrameHostManager corresponding to the parent's
+// SiteInstance, A2 in the picture above. When a child frame navigates in a new
+// process, SetView() is called to update to the new view.
+//
+class CONTENT_EXPORT CrossProcessFrameConnectorBase
+    : public input::ChildFrameInputHelper::Delegate {
+ public:
+  ~CrossProcessFrameConnectorBase() override = default;
+
+  // These values are written to logs. Do not renumber or delete existing items;
+  // add new entries to the end of the list.
+  enum class RootViewFocusState {
+    // RootView is NULL.
+    kNullView = 0,
+    // Root View is already focused.
+    kFocused = 1,
+    // Root View is not focused at TouchStart. Calls
+    // RenderWidgetHostViewChildFrame::Focus() to focus it.
+    kNotFocused = 2,
+    kMaxValue = kNotFocused
+  };
+
+  virtual void SetView(RenderWidgetHostViewChildFrame* view,
+                       bool allow_paint_holding) = 0;
+
+  // Returns the parent RenderWidgetHostView or nullptr if it doesn't have one.
+  virtual RenderWidgetHostViewBase* GetParentRenderWidgetHostView() = 0;
+
+  // Returns the view for the top-level frame under the same WebContents.
+  virtual RenderWidgetHostViewBase* GetRootRenderWidgetHostView() = 0;
+
+  // Notify the frame connector that the renderer process has terminated.
+  virtual void RenderProcessGone() = 0;
+
+  // Provide the SurfaceInfo to the embedder, which becomes a reference to the
+  // current view's Surface that is included in higher-level compositor
+  // frames. This is virtual to be overridden in tests.
+  virtual void FirstSurfaceActivation(const viz::SurfaceInfo& surface_info) = 0;
+
+  // Sends the given intrinsic sizing information from a sub-frame to
+  // its corresponding remote frame in the parent frame's renderer.
+  virtual void SendIntrinsicSizingInfoToParent(
+      blink::mojom::IntrinsicSizingInfoPtr) = 0;
+
+  // Record and apply new visual properties for the subframe. If 'propagate' is
+  // true, the new properties will be sent to the subframe's renderer process.
+  virtual void SynchronizeVisualProperties(
+      const blink::FrameVisualProperties& visual_properties,
+      bool propagate = true) = 0;
+
+  // Request that the platform change the mouse cursor when the mouse is
+  // positioned over this view's content.
+  virtual void UpdateCursor(const ui::Cursor& cursor) = 0;
+
+  // Determines whether the root RenderWidgetHostView (and thus the current
+  // page) has focus. We need a tri-state enum as a return variable to
+  // differentiate between the cases where root view is NULL and when it's
+  // actually focused/unfocused. No behaviour change expected in focus handling.
+  virtual RootViewFocusState HasFocus() = 0;
+
+  // Cause the root RenderWidgetHostView to become focused.
+  virtual void FocusRootView() = 0;
+
+  // Locks the mouse pointer, if |request_unadjusted_movement_| is true, try
+  // setting the unadjusted movement mode. Returns true if mouse pointer is
+  // locked.
+  virtual blink::mojom::PointerLockResult LockPointer(
+      bool request_unadjusted_movement) = 0;
+
+  // Change the current pointer lock to match the unadjusted movement option
+  // given.
+  virtual blink::mojom::PointerLockResult ChangePointerLock(
+      bool request_unadjusted_movement) = 0;
+
+  // Unlocks the mouse pointer if it is locked.
+  virtual void UnlockPointer() = 0;
+
+  virtual bool HasSize() const = 0;
+  virtual const display::ScreenInfos& GetScreenInfos() const = 0;
+  virtual const viz::LocalSurfaceId& GetLocalSurfaceId() const = 0;
+  virtual const blink::mojom::ViewportIntersectionState& GetIntersectionState()
+      const = 0;
+  virtual uint32_t GetCaptureSequenceNumber() const = 0;
+  virtual const gfx::Rect& GetRectInParentViewInDip() const = 0;
+  virtual const gfx::Size& GetLocalFrameSizeInDip() const = 0;
+  virtual const gfx::Size& GetLocalFrameSizeInPixels() const = 0;
+  virtual double GetCssZoomFactor() const = 0;
+
+  // Informs the parent the child will enter auto-resize mode, automatically
+  // resizing itself to the provided |min_size| and |max_size| constraints.
+  virtual void EnableAutoResize(const gfx::Size& min_size,
+                                const gfx::Size& max_size) = 0;
+
+  // Turns off auto-resize mode.
+  virtual void DisableAutoResize() = 0;
+
+  // Determines whether the current view's content is inert, either because
+  // an HTMLDialogElement is being modally displayed in a higher-level frame,
+  // or because the inert attribute has been specified.
+  virtual bool IsInert() const = 0;
+
+  // Returns the inherited effective touch action property that should be
+  // applied to any nested child RWHVCFs inside the caller RWHVCF.
+  virtual cc::TouchAction InheritedEffectiveTouchAction() const = 0;
+
+  // Determines whether the RenderWidgetHostViewChildFrame is hidden due to
+  // a higher-level embedder being hidden. This is distinct from the
+  // RenderWidgetHostImpl being hidden, which is a property set when
+  // RenderWidgetHostView::Hide() is called on the current view.
+  virtual bool IsHidden() const = 0;
+
+  // IsThrottled() indicates that the frame is outside of it's parent frame's
+  // visible viewport, and should be render throttled.
+  virtual bool IsThrottled() const = 0;
+  // IsSubtreeThrottled() indicates that IsThrottled() is true for one of this
+  // frame's ancestors, which means this frame must also be throttled.
+  virtual bool IsSubtreeThrottled() const = 0;
+  // IsDisplayLocked() indicates that a DOM ancestor of this frame's owning
+  // <iframe> element in the parent frame is currently display locked; or that
+  // IsDisplayLocked() is true for one of this frame's ancestors; which means
+  // this frame should be render throttled.
+  virtual bool IsDisplayLocked() const = 0;
+
+  // Called by RenderWidgetHostViewChildFrame when the child frame has updated
+  // its visual properties and its viz::LocalSurfaceId has changed.
+  virtual void DidUpdateVisualProperties(
+      const cc::RenderFrameMetadata& metadata) = 0;
+
+  // Called by RenderWidgetHostViewChildFrame to update the visibility of any
+  // nested child RWHVCFs inside it.
+  virtual void SetVisibilityForChildViews(bool visible) const = 0;
+
+  // Called to resize the child renderer's CompositorFrame.
+  // |local_frame_size| is in pixels if zoom-for-dsf is enabled, and in DIP
+  // if not.
+  virtual void SetLocalFrameSize(const gfx::Size& local_frame_size) = 0;
+
+  // Called to resize the child renderer. |rect_in_parent_view| is in physical
+  // pixels.
+  virtual void SetRectInParentView(const gfx::Rect& rect_in_parent_view) = 0;
+
+  virtual void SetIsInert(bool inert) = 0;
+
+  // Handlers for messages received from the parent frame called
+  // from RenderFrameProxyHost to be sent to |view_|.
+  virtual void OnSetInheritedEffectiveTouchAction(cc::TouchAction) = 0;
+  virtual void OnVisibilityChanged(
+      blink::mojom::FrameVisibility visibility) = 0;
+
+  virtual void UpdateRenderThrottlingStatus(bool is_throttled,
+                                            bool subtree_throttled,
+                                            bool display_locked) = 0;
+  virtual void UpdateViewportIntersection(
+      const blink::mojom::ViewportIntersectionState& intersection_state,
+      const std::optional<blink::FrameVisualProperties>& visual_properties) = 0;
+
+  // Returns whether the child widget is actually visible to the user.  This is
+  // different from the IsHidden override, and takes into account viewport
+  // intersection as well as the visibility of the RenderFrameHostDelegate.
+  virtual bool IsVisible() = 0;
+
+  // This function is called by the RenderFrameHostDelegate to signal that it
+  // became visible. This is called after any navigations resulting from
+  // visibility changes have been queued (e.g. if needs-reload was set).
+  virtual void DelegateWasShown() = 0;
+
+  // Handlers for messages received from the parent frame.
+  virtual void OnSynchronizeVisualProperties(
+      const blink::FrameVisualProperties& visual_properties) = 0;
+
+  // Returns the embedder's visibility.
+  virtual Visibility EmbedderVisibility() = 0;
+};
+
+}  // namespace content
+
+#endif  // CONTENT_BROWSER_RENDERER_HOST_CROSS_PROCESS_FRAME_CONNECTOR_BASE_H_

--- a/content/browser/renderer_host/render_widget_host_view_child_frame.cc
+++ b/content/browser/renderer_host/render_widget_host_view_child_frame.cc
@@ -243,7 +243,7 @@ void RenderWidgetHostViewChildFrame::EnsureSurfaceSynchronizedForWebTest() {
 uint32_t RenderWidgetHostViewChildFrame::GetCaptureSequenceNumber() const {
   if (!frame_connector_)
     return 0u;
-  return frame_connector_->capture_sequence_number();
+  return frame_connector_->GetCaptureSequenceNumber();
 }
 
 void RenderWidgetHostViewChildFrame::ShowWithVisibility(
@@ -285,7 +285,7 @@ void RenderWidgetHostViewChildFrame::WasUnOccluded() {
 gfx::Rect RenderWidgetHostViewChildFrame::GetViewBounds() {
   gfx::Rect screen_space_rect;
   if (frame_connector_) {
-    screen_space_rect = frame_connector_->rect_in_parent_view_in_dip();
+    screen_space_rect = frame_connector_->GetRectInParentViewInDip();
 
     RenderWidgetHostView* parent_view =
         frame_connector_->GetParentRenderWidgetHostView();
@@ -301,7 +301,7 @@ gfx::Rect RenderWidgetHostViewChildFrame::GetViewBounds() {
     // on. We want the location of the frame in screen coordinates to place
     // popups but we want the size in local coordinates to produce the right-
     // sized CompositorFrames. https://crbug.com/928825.
-    screen_space_rect.set_size(frame_connector_->local_frame_size_in_dip());
+    screen_space_rect.set_size(frame_connector_->GetLocalFrameSizeInDip());
   }
   return screen_space_rect;
 }
@@ -407,7 +407,7 @@ void RenderWidgetHostViewChildFrame::
 
 gfx::Size RenderWidgetHostViewChildFrame::GetCompositorViewportPixelSize() {
   if (frame_connector_)
-    return frame_connector_->local_frame_size_in_pixels();
+    return frame_connector_->GetLocalFrameSizeInPixels();
   return gfx::Size();
 }
 
@@ -456,13 +456,13 @@ void RenderWidgetHostViewChildFrame::UpdateCursor(const ui::Cursor& cursor) {
 
 void RenderWidgetHostViewChildFrame::UpdateScreenInfo() {
   if (frame_connector_)
-    screen_infos_ = frame_connector_->screen_infos();
+    screen_infos_ = frame_connector_->GetScreenInfos();
 }
 
 void RenderWidgetHostViewChildFrame::SendInitialPropertiesIfNeeded() {
   if (initial_properties_sent_ || !frame_connector_)
     return;
-  UpdateViewportIntersection(frame_connector_->intersection_state(),
+  UpdateViewportIntersection(frame_connector_->GetIntersectionState(),
                              std::nullopt);
   SetIsInert();
   UpdateInheritedEffectiveTouchAction();
@@ -721,10 +721,13 @@ const viz::FrameSinkId& RenderWidgetHostViewChildFrame::GetFrameSinkId() const {
   return frame_sink_id_;
 }
 
-const viz::LocalSurfaceId& RenderWidgetHostViewChildFrame::GetLocalSurfaceId()
-    const {
+const viz::LocalSurfaceId&
+
+RenderWidgetHostViewChildFrame::GetLocalSurfaceId() const {
   if (frame_connector_)
-    return frame_connector_->local_surface_id();
+
+    return frame_connector_->GetLocalSurfaceId();
+
   return viz::ParentLocalSurfaceIdAllocator::InvalidLocalSurfaceId();
 }
 
@@ -786,11 +789,11 @@ viz::SurfaceId RenderWidgetHostViewChildFrame::GetCurrentSurfaceId() const {
 }
 
 bool RenderWidgetHostViewChildFrame::HasSize() const {
-  return frame_connector_ && frame_connector_->has_size();
+  return frame_connector_ && frame_connector_->HasSize();
 }
 
 double RenderWidgetHostViewChildFrame::GetCSSZoomFactor() const {
-  return frame_connector_ ? frame_connector_->css_zoom_factor() : 1.0;
+  return frame_connector_ ? frame_connector_->GetCssZoomFactor() : 1.0;
 }
 
 gfx::PointF RenderWidgetHostViewChildFrame::TransformPointToRootCoordSpaceF(

--- a/content/browser/site_per_process_layout_browsertest.cc
+++ b/content/browser/site_per_process_layout_browsertest.cc
@@ -1072,7 +1072,7 @@ IN_PROC_BROWSER_TEST_P(SitePerProcessBrowserTest,
   auto b1_intersection_state = b1_node->render_manager()
                                    ->GetProxyToParent()
                                    ->cross_process_frame_connector()
-                                   ->intersection_state();
+                                   ->GetIntersectionState();
 
   b1_intersection_state.outermost_main_frame_scroll_position.Offset(10, 0);
   // A change in outermost_main_frame_scroll_position by itself will not cause
@@ -1087,7 +1087,7 @@ IN_PROC_BROWSER_TEST_P(SitePerProcessBrowserTest,
   auto b2_intersection_state = b2_node->render_manager()
                                    ->GetProxyToParent()
                                    ->cross_process_frame_connector()
-                                   ->intersection_state();
+                                   ->GetIntersectionState();
 
   b2_intersection_state.outermost_main_frame_scroll_position.Offset(20, 0);
   b2_intersection_state.viewport_intersection.set_y(
@@ -1396,11 +1396,11 @@ IN_PROC_BROWSER_TEST_P(SitePerProcessBrowserTest,
   // good way to avoid this due to various device-scale-factor. (e.g. when
   // dsf=3.375, ceil(round(50 * 3.375) / 3.375) = 51. Thus, we allow the screen
   // size in dip to be off by 1 here.
-  EXPECT_NEAR(50, connector->rect_in_parent_view_in_dip().size().width(), 1);
-  EXPECT_NEAR(50, connector->rect_in_parent_view_in_dip().size().height(), 1);
+  EXPECT_NEAR(50, connector->GetRectInParentViewInDip().size().width(), 1);
+  EXPECT_NEAR(50, connector->GetRectInParentViewInDip().size().height(), 1);
   EXPECT_EQ(gfx::Size(100, 100), rwhv_nested->GetViewBounds().size());
-  EXPECT_EQ(gfx::Size(100, 100), connector->local_frame_size_in_dip());
-  EXPECT_EQ(connector->local_frame_size_in_pixels(),
+  EXPECT_EQ(gfx::Size(100, 100), connector->GetLocalFrameSizeInDip());
+  EXPECT_EQ(connector->GetLocalFrameSizeInPixels(),
             rwhv_nested->GetCompositorViewportPixelSize());
 }
 

--- a/content/public/test/browser_test_utils.cc
+++ b/content/public/test/browser_test_utils.cc
@@ -4427,7 +4427,7 @@ void ProxyDSFObserver::OnCreation(RenderFrameProxyHost* rfph) {
   // CrossProcessFrameConnector. We're only interested in the ones that do.
   if (auto* cpfc = rfph->cross_process_frame_connector()) {
     proxy_host_created_dsf_.push_back(
-        cpfc->screen_infos().current().device_scale_factor);
+        cpfc->GetScreenInfos().current().device_scale_factor);
   }
   if (runner_) {
     runner_->Quit();


### PR DESCRIPTION
We add an abstract class  `CrossProcessFrameConnectorBase` to insert in the inheritance between `input::ChildFrameInputHelper::Delegate` and `CrossProcessFrameConnector`. Eventually `SecureEmbedHost` will also implement `CrossProcessFrameConnectorBase`.