### PR TITLE
Convert guest_contents to a build component

### DIFF
--- a/components/guest_contents/browser/BUILD.gn
+++ b/components/guest_contents/browser/BUILD.gn
@@ -6,7 +6,9 @@ import("//mojo/public/tools/bindings/mojom.gni")
 
 assert(enable_guest_contents)
 
-static_library("browser") {
+component("browser") {
+  defines = [ "IS_GUEST_CONTENTS_IMPL" ]
+
   sources = [
     "guest_contents_handle.cc",
     "guest_contents_handle.h",

--- a/components/guest_contents/browser/guest_contents_handle.h
+++ b/components/guest_contents/browser/guest_contents_handle.h
@@ -5,6 +5,7 @@
 #ifndef COMPONENTS_GUEST_CONTENTS_BROWSER_GUEST_CONTENTS_HANDLE_H_
 #define COMPONENTS_GUEST_CONTENTS_BROWSER_GUEST_CONTENTS_HANDLE_H_
 
+#include "base/component_export.h"
 #include "base/sequence_checker.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_observer.h"
@@ -17,7 +18,7 @@ using GuestId = int;
 // A handle for a guest WebContents, uniquely identified by a GuestId. It
 // provides APIs for attaching and detaching the guest WebContents from the
 // outer WebContents. It has the same lifetime as the guest WebContents.
-class GuestContentsHandle
+class COMPONENT_EXPORT(GUEST_CONTENTS) GuestContentsHandle
     : public content::WebContentsUserData<GuestContentsHandle>,
       public content::WebContentsObserver {
  public:

--- a/components/guest_contents/browser/guest_contents_host_impl.h
+++ b/components/guest_contents/browser/guest_contents_host_impl.h
@@ -5,6 +5,7 @@
 #ifndef COMPONENTS_GUEST_CONTENTS_BROWSER_GUEST_CONTENTS_HOST_IMPL_H_
 #define COMPONENTS_GUEST_CONTENTS_BROWSER_GUEST_CONTENTS_HOST_IMPL_H_
 
+#include "base/component_export.h"
 #include "base/values.h"
 #include "components/guest_contents/browser/guest_contents_handle.h"
 #include "components/guest_contents/common/guest_contents.mojom.h"
@@ -20,8 +21,9 @@ namespace guest_contents {
 
 // Implements the mojom::GuestContentsHost interface available in the browser
 // process on a WebUIController.
-class GuestContentsHostImpl : public mojom::GuestContentsHost,
-                              public content::WebContentsObserver {
+class COMPONENT_EXPORT(GUEST_CONTENTS) GuestContentsHostImpl
+    : public mojom::GuestContentsHost,
+      public content::WebContentsObserver {
  public:
   // The binder function used by WebUIController to create an implementation of
   // mojom::GuestContentsHost for the outer WebContents.


### PR DESCRIPTION
Follow-up changes will take a dependency on guest contents to pass through the WebContents to attach. Converting guest_contents to a component will keep component builds working when that happens.