### PR TITLE
Use SolidColorLayer for drawing SecureEmbedWebPlugin

### DIFF
--- a/components/secure_embed/renderer/secure_embed_web_plugin.cc
+++ b/components/secure_embed/renderer/secure_embed_web_plugin.cc
@@ -55,8 +55,6 @@ bool SecureEmbedWebPlugin::Initialize(blink::WebPluginContainer* container) {
   layer_ = cc::SolidColorLayer::Create();
   layer_->SetBackgroundColor(SkColors::kRed);
   layer_->SetIsDrawable(true);
-
-  // Provide the layer to the container
   container_->SetCcLayer(layer_.get());
 
   if (host_) {
@@ -114,7 +112,7 @@ void SecureEmbedWebPlugin::UpdateAllLifecyclePhases(
 void SecureEmbedWebPlugin::Paint(cc::PaintCanvas* canvas,
                                  const gfx::Rect& rect) {
   // No-op: rendering is now handled by the compositor layer
-  DCHECK(false);
+  NOTREACHED();
 }
 
 void SecureEmbedWebPlugin::UpdateGeometry(const gfx::Rect& window_rect,
@@ -123,6 +121,9 @@ void SecureEmbedWebPlugin::UpdateGeometry(const gfx::Rect& window_rect,
                                           bool is_visible) {
   // Note: Layer bounds are set by WebPluginContainerImpl::Paint()
   // so we don't need to set them here for the time being.
+
+  // TODO(secure-embed): This will need updated to propagate the geometry to the
+  // embedded content.
 }
 
 void SecureEmbedWebPlugin::UpdateFocus(bool focused,

--- a/components/secure_embed/renderer/secure_embed_web_plugin.h
+++ b/components/secure_embed/renderer/secure_embed_web_plugin.h
@@ -72,7 +72,8 @@ class SecureEmbedWebPlugin : public blink::WebPlugin,
   int contents_id_ = -1;
 
   raw_ptr<blink::WebPluginContainer> container_ = nullptr;
-
+  // TODO(secure-embed): This will be converted to be a SurfaceLayer or may be
+  // kept as part of placeholder rendering if supported.
   scoped_refptr<cc::SolidColorLayer> layer_;
 
   mojo::AssociatedRemote<mojom::SecureEmbedHost> host_;


### PR DESCRIPTION
Change to using a solid color layer instead of painting directly. This is more closely aligned with how we expect the plugin to eventually integrate embedded content, via SurfaceLayer. It also allows us to verify that WebPluginContainer::SetCcLayer works as expected.