### PR TITLE
Add <secureembed> support to webui_examples

### DIFF
--- a/ui/webui/examples/BUILD.gn
+++ b/ui/webui/examples/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/ui.gni")
+import("//components/secure_embed/buildflags/buildflags.gni")
 import("//mojo/public/tools/bindings/mojom.gni")
 import("//tools/grit/grit_rule.gni")
 import("//tools/grit/repack.gni")
@@ -88,6 +89,15 @@ static_library("webui_examples_lib") {
       "//ui/aura:test_support",
       "//ui/wm",
       "//ui/wm/public",
+    ]
+  }
+
+  if (enable_secure_embed) {
+    deps += [
+      "//components/secure_embed/browser",
+      "//components/secure_embed/buildflags",
+      "//components/secure_embed/renderer",
+      "//services/network/public/mojom:mojom_content_security_policy",
     ]
   }
 

--- a/ui/webui/examples/browser/content_browser_client.cc
+++ b/ui/webui/examples/browser/content_browser_client.cc
@@ -6,6 +6,7 @@
 
 #include "components/embedder_support/user_agent_utils.h"
 #include "components/guest_contents/common/guest_contents.mojom.h"
+#include "components/secure_embed/buildflags/buildflags.h"
 #include "content/public/browser/devtools_manager_delegate.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/web_contents_view_delegate.h"
@@ -14,6 +15,10 @@
 #include "ui/webui/examples/browser/browser_main_parts.h"
 #include "ui/webui/examples/browser/ui/web/browser.h"
 #include "ui/webui/examples/browser/ui/web/browser.mojom.h"
+
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+#include "components/secure_embed/browser/secure_embed_host.h"
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
 
 namespace webui_examples {
 
@@ -47,6 +52,22 @@ void ContentBrowserClient::RegisterBrowserInterfaceBindersForFrame(
   RegisterWebUIControllerInterfaceBinder<
       guest_contents::mojom::GuestContentsHost, Browser>(map);
 }
+
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+void ContentBrowserClient::RegisterAssociatedInterfaceBindersForRenderFrameHost(
+    content::RenderFrameHost& render_frame_host,
+    blink::AssociatedInterfaceRegistry& associated_registry) {
+  associated_registry.AddInterface<secure_embed::mojom::SecureEmbedHost>(
+      base::BindRepeating(
+          [](content::RenderFrameHost* render_frame_host,
+             mojo::PendingAssociatedReceiver<
+                 secure_embed::mojom::SecureEmbedHost> receiver) {
+            secure_embed::SecureEmbedHost::Create(render_frame_host,
+                                                  std::move(receiver));
+          },
+          &render_frame_host));
+}
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
 
 std::string ContentBrowserClient::GetUserAgent() {
   return embedder_support::GetUserAgent();

--- a/ui/webui/examples/browser/content_browser_client.h
+++ b/ui/webui/examples/browser/content_browser_client.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "base/memory/raw_ptr.h"
+#include "components/secure_embed/buildflags/buildflags.h"
 #include "content/public/browser/content_browser_client.h"
 
 namespace webui_examples {
@@ -32,6 +33,11 @@ class ContentBrowserClient : public content::ContentBrowserClient {
   void RegisterBrowserInterfaceBindersForFrame(
       content::RenderFrameHost* render_frame_host,
       mojo::BinderMapWithContext<content::RenderFrameHost*>* map) override;
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+  void RegisterAssociatedInterfaceBindersForRenderFrameHost(
+      content::RenderFrameHost& render_frame_host,
+      blink::AssociatedInterfaceRegistry& associated_registry) override;
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
   std::string GetUserAgent() override;
 
   raw_ptr<BrowserMainParts, AcrossTasksDanglingUntriaged> browser_main_parts_ =

--- a/ui/webui/examples/browser/ui/web/browser.cc
+++ b/ui/webui/examples/browser/ui/web/browser.cc
@@ -6,6 +6,7 @@
 
 #include "components/guest_contents/browser/guest_contents_handle.h"
 #include "components/guest_contents/browser/guest_contents_host_impl.h"
+#include "components/secure_embed/buildflags/buildflags.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/render_process_host.h"
 #include "content/public/browser/web_contents.h"
@@ -13,6 +14,10 @@
 #include "content/public/browser/web_ui_data_source.h"
 #include "ui/webui/examples/browser/ui/web/browser_page_handler.h"
 #include "ui/webui/examples/resources/browser/grit/webui_examples_browser_resources.h"
+
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+#include "services/network/public/mojom/content_security_policy.mojom.h"
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
 
 namespace webui_examples {
 
@@ -29,6 +34,11 @@ Browser::Browser(content::WebUI* web_ui)
   content::WebUIDataSource* html_source =
       content::WebUIDataSource::CreateAndAdd(browser_context, kMainUI);
   html_source->UseStringsJs();
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+  // Allow the embed element (default CSP blocks object-src with 'none')
+  html_source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::ObjectSrc, "object-src 'self';");
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
   html_source->AddResourcePath("index.js", IDR_WEBUI_EXAMPLES_BROWSER_INDEX_JS);
   html_source->AddResourcePath("index.css",
                                IDR_WEBUI_EXAMPLES_BROWSER_INDEX_CSS);

--- a/ui/webui/examples/renderer/content_renderer_client.cc
+++ b/ui/webui/examples/renderer/content_renderer_client.cc
@@ -4,10 +4,15 @@
 
 #include "ui/webui/examples/renderer/content_renderer_client.h"
 
+#include "components/secure_embed/buildflags/buildflags.h"
 #include "content/public/renderer/render_frame.h"
 #include "third_party/blink/public/platform/web_string.h"
 #include "third_party/blink/public/web/web_custom_element.h"
 #include "ui/webui/examples/renderer/render_frame_observer.h"
+
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+#include "components/secure_embed/renderer/create_plugin.h"
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
 
 namespace webui_examples {
 
@@ -30,6 +35,20 @@ void ContentRendererClient::RenderFrameCreated(
 void ContentRendererClient::RenderThreadStarted() {
   blink::WebCustomElement::AddEmbedderCustomElementName(
       blink::WebString("webview"));
+  blink::WebCustomElement::AddEmbedderCustomElementName(
+      blink::WebString("secureembed"));
 }
+
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+bool ContentRendererClient::OverrideCreatePlugin(
+    content::RenderFrame* render_frame,
+    const blink::WebPluginParams& params,
+    blink::WebPlugin** plugin) {
+  if (secure_embed::MaybeCreatePlugin(render_frame, params, plugin)) {
+    return true;
+  }
+  return false;
+}
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
 
 }  // namespace webui_examples

--- a/ui/webui/examples/renderer/content_renderer_client.h
+++ b/ui/webui/examples/renderer/content_renderer_client.h
@@ -5,6 +5,7 @@
 #ifndef UI_WEBUI_EXAMPLES_RENDERER_CONTENT_RENDERER_CLIENT_H_
 #define UI_WEBUI_EXAMPLES_RENDERER_CONTENT_RENDERER_CLIENT_H_
 
+#include "components/secure_embed/buildflags/buildflags.h"
 #include "content/public/renderer/content_renderer_client.h"
 
 namespace webui_examples {
@@ -20,6 +21,11 @@ class ContentRendererClient : public content::ContentRendererClient {
   // content::ContentRendererClient:
   void RenderFrameCreated(content::RenderFrame* render_frame) override;
   void RenderThreadStarted() override;
+#if BUILDFLAG(ENABLE_SECURE_EMBED)
+  bool OverrideCreatePlugin(content::RenderFrame* render_frame,
+                            const blink::WebPluginParams& params,
+                            blink::WebPlugin** plugin) override;
+#endif  // BUILDFLAG(ENABLE_SECURE_EMBED)
 };
 
 }  // namespace webui_examples

--- a/ui/webui/examples/renderer/render_frame_observer.cc
+++ b/ui/webui/examples/renderer/render_frame_observer.cc
@@ -43,7 +43,16 @@ void AllowCustomElementNameRegistration(v8::Local<v8::Function> callback) {
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   blink::WebCustomElement::EmbedderNamesAllowedScope embedder_names_scope;
-  callback->Call(context, context->Global(), 0, nullptr).ToLocalChecked();
+  v8::TryCatch try_catch(isolate);
+  v8::MaybeLocal<v8::Value> result =
+      callback->Call(context, context->Global(), 0, nullptr);
+  if (result.IsEmpty()) {
+    v8::String::Utf8Value exception(isolate, try_catch.Exception());
+    v8::String::Utf8Value stack_trace(
+        isolate, try_catch.StackTrace(context).ToLocalChecked());
+    LOG(ERROR) << "AllowCustomElementNameRegistration failed:" << *exception
+               << "\nStack trace: " << *stack_trace;
+  }
 }
 
 content::RenderFrame* GetRenderFrame(v8::Local<v8::Value> value) {

--- a/ui/webui/examples/resources/browser/index.css
+++ b/ui/webui/examples/resources/browser/index.css
@@ -28,3 +28,10 @@ webview {
 
   flex: 1;
 }
+
+secureembed {
+  display: flex;
+  flex-direction: column;
+
+  flex: 1;
+}

--- a/ui/webui/examples/resources/browser/index.html
+++ b/ui/webui/examples/resources/browser/index.html
@@ -6,11 +6,12 @@
 <body>
   <script type="module" src="index.js"></script>
   <div id="navbar">
+    <input id="attach-guest" type="button" value="Attach via Guest Contents" />
+    <input id="attach-secure-embed" type="button" value="Attach via SecureEmbed" />
     <input id="back" type="button" value="Back" />
     <input id="forward" type="button" value="Forward" />
     <input id="address" type="text" />
     <input id="go" type="button" value="Go" />
   </div>
-  <webview id="webview"></webview>
 </body>
 </html>

--- a/ui/webui/examples/resources/browser/index.ts
+++ b/ui/webui/examples/resources/browser/index.ts
@@ -41,6 +41,7 @@ class BrowserProxy {
 class WebviewElement extends HTMLElement {
   public iframeElement: HTMLIFrameElement;
   private guestContentsId: number;
+  private attached: boolean = false;
 
   constructor() {
     super();
@@ -49,12 +50,56 @@ class WebviewElement extends HTMLElement {
     this.iframeElement.style.margin = "0";
     this.iframeElement.style.padding = "0";
     this.iframeElement.style.flex = '1';
-    this.appendChild(this.iframeElement);
     this.guestContentsId = loadTimeData.getInteger('guest-contents-id');
     console.log('guest-contents-id', this.guestContentsId);
-    const iframeContentWindow = this.iframeElement.contentWindow;
-    webshell.attachIframeGuest(this.guestContentsId,
-                               iframeContentWindow);
+  }
+
+  connectedCallback() {
+    if (!this.attached) {
+      this.appendChild(this.iframeElement);
+      this.attached = true;
+      const iframeContentWindow = this.iframeElement.contentWindow;
+      webshell.attachIframeGuest(this.guestContentsId,
+                                iframeContentWindow);
+    }
+  }
+
+  navigate(src: MojoUrl) {
+    BrowserProxy.getInstance().navigate(this.guestContentsId, src);
+  }
+
+  goBack() {
+    BrowserProxy.getInstance().goBack(this.guestContentsId);
+  }
+
+  goForward() {
+    BrowserProxy.getInstance().goForward(this.guestContentsId);
+  }
+}
+
+class SecureEmbedElement extends HTMLElement {
+  public embedElement: HTMLEmbedElement;
+  private guestContentsId: number;
+  private attached: boolean = false;
+
+  constructor() {
+    super();
+    this.embedElement = document.createElement('embed');
+    this.embedElement.style.border = '0px';
+    this.embedElement.style.margin = "0";
+    this.embedElement.style.padding = "0";
+    this.embedElement.style.flex = '1';
+    this.guestContentsId = loadTimeData.getInteger('guest-contents-id');
+    console.log('secure-embed guest-contents-id', this.guestContentsId);
+    this.embedElement.setAttribute('data-content-id', this.guestContentsId.toString());
+    this.embedElement.setAttribute('type', 'application/x-google-chrome-secure-embed');
+  }
+
+  connectedCallback() {
+    if (!this.attached) {
+      this.appendChild(this.embedElement);
+      this.attached = true;
+    }
   }
 
   navigate(src: MojoUrl) {
@@ -72,19 +117,55 @@ class WebviewElement extends HTMLElement {
 
 webshell.allowWebviewElementRegistration(() => {
   customElements.define("webview", WebviewElement);
+  customElements.define("secureembed", SecureEmbedElement);
 });
 
+let currentEmbedElement: WebviewElement | SecureEmbedElement | null = null;
+
+function attachViaGuestContents() {
+  if (currentEmbedElement) {
+    currentEmbedElement.remove();
+  }
+
+  // Create and attach WebviewElement
+  const webview = document.createElement("webview") as WebviewElement;
+  webview.id = "webview";
+  document.body.appendChild(webview);
+  currentEmbedElement = webview;
+}
+
+function attachViaSecureEmbed() {
+  if (currentEmbedElement) {
+    currentEmbedElement.remove();
+  }
+
+  // Create and attach SecureEmbedElement
+  const secureEmbed = document.createElement("secureembed") as SecureEmbedElement;
+  secureEmbed.id = "webview";
+  document.body.appendChild(secureEmbed);
+  currentEmbedElement = secureEmbed;
+}
+
+const attachGuestButton = document.getElementById("attach-guest");
+if (attachGuestButton) {
+  attachGuestButton.addEventListener("click", attachViaGuestContents);
+}
+
+const attachSecureEmbedButton = document.getElementById("attach-secure-embed");
+if (attachSecureEmbedButton) {
+  attachSecureEmbedButton.addEventListener("click", attachViaSecureEmbed);
+}
+
 function navigateToAddressBarUrl() {
-  const webview = document.getElementById("webview") as WebviewElement;
   const addressBar = document.getElementById("address") as HTMLInputElement;
-  if (webview && addressBar) {
+  if (currentEmbedElement && addressBar) {
     try {
       // Validate the URL before converting it to a Mojo URL to avoid a Mojo
       // validation error when sending this call to the browser. Successful
       // construction indicates a valid URL.
       const src = new URL(addressBar.value);
       const mojoSrc: MojoUrl = {url: src.toString()};
-      webview.navigate(mojoSrc);
+      currentEmbedElement.navigate(mojoSrc);
     } catch (error) {
       console.error(error);
     }
@@ -109,9 +190,8 @@ if (addressBar) {
 const backButton = document.getElementById("back");
 if (backButton) {
   backButton.addEventListener("click", ()=>{
-    const webview = document.getElementById("webview") as WebviewElement;
-    if (webview) {
-      webview.goBack();
+    if (currentEmbedElement) {
+      currentEmbedElement.goBack();
     }
   });
 }
@@ -119,9 +199,8 @@ if (backButton) {
 const forwardButton = document.getElementById("forward");
 if (forwardButton) {
   forwardButton.addEventListener("click", ()=>{
-    const webview = document.getElementById("webview") as WebviewElement;
-    if (webview) {
-      webview.goForward();
+    if (currentEmbedElement) {
+      currentEmbedElement.goForward();
     }
   });
 }


### PR DESCRIPTION
This CL adds <secureembed> support to webui_examples. It's implemented in a way that preserves the existing GuestContents approach as well, allowing one to compare and contrast the two approaches.

Changes include:

Browser-side:

* Registered SecureEmbedHost associated interface binder
* Modified CSP policy to allow object-src for embed elements

Renderer-side:

* Registered "secureembed" as a custom element name
* Implemented OverrideCreatePlugin to handle SecureEmbed plugin creation

WebUI:

* Created SecureEmbedElement custom element that wraps an embed element
* Added UI buttons to switch between GuestContents and SecureEmbed modes
* Refactored to support dynamic attachment/detachment

Note: This change has a dependency on data-content-id support.

The secureembed version doesn't show the webpage content yet, but one can tell it is working due to the red painting and the log message emitted by the browser process:

Successfully retrieved WebContents for content_id: 0