### PR TITLE
Fix components_unittests component build

### DIFF
--- a/components/guest_contents/browser/BUILD.gn
+++ b/components/guest_contents/browser/BUILD.gn
@@ -37,6 +37,7 @@ source_set("unit_tests") {
   deps = [
     ":browser",
     "//base",
+    "//components/guest_contents/common:mojom",
     "//testing/gtest",
   ]
 }


### PR DESCRIPTION
The previous change to make guest_contents a component meant that the component build of components_unittests was linking against the :browser component DLL instead of the original source. As only symbols used by the :browser's sources are included in the component DLL, other guest contents symbols were missing. Adding an explicit deps for the unit_tests fixes the issue.