### PR TITLE
Cherry pick: Webium: fix a crash during browser closing (orig. by Liang Zhao)

### DIFF
--- a/chrome/browser/ui/webui_browser/webui_browser_window.cc
+++ b/chrome/browser/ui/webui_browser/webui_browser_window.cc
@@ -1206,10 +1206,7 @@ void WebUIBrowserWindow::OnWindowCloseRequested(
     // immediately) and close all the tabs, allowing the renderers to shut
     // down. When the tab strip is empty we'll be called back again.
     widget_->Hide();
-    return;
   }
-
-  browser_->SynchronouslyDestroyBrowser();
 }
 
 WebUIBrowserWindow::WidgetDelegate::WidgetDelegate(


### PR DESCRIPTION
This cherry picks Liang Zhao's fix to Webium's exit crashes to secure-embed branch, since the bug is very detremental to development productivity (at least on Linux).

Original commit message:
--------------
Currently when closing webui browser, the Browser object is destroyed synchronously from Browser::CloseContents and the process crashes when we try to use the object and the objects that it owns later within the same call.

As Browser::OnWindowClosing() already has code to delete the Browser object asynchronously, we should not call SynchronouslyDestroyBrowser from WebUIBrowserWindow code. Removing the call avoids the crash.

Bug: 393144165
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7001739
Reviewed-by: Tom Lukaszewicz <tluk@chromium.org>
Reviewed-by: Keren Zhu <kerenzhu@chromium.org>
Commit-Queue: Liang Zhao <lzhao@microsoft.com>
Cr-Commit-Position: refs/heads/main@{#1523655}