### PR TITLE
Use CrossProcessFrameConnectorBase in RenderWidgetHostViewChildFrame

### DIFF
--- a/content/browser/renderer_host/render_widget_host_view_child_frame.cc
+++ b/content/browser/renderer_host/render_widget_host_view_child_frame.cc
@@ -117,7 +117,7 @@ void RenderWidgetHostViewChildFrame::
 }
 
 void RenderWidgetHostViewChildFrame::SetFrameConnector(
-    CrossProcessFrameConnector* frame_connector) {
+    CrossProcessFrameConnectorBase* frame_connector) {
   if (frame_connector_ == frame_connector)
     return;
 
@@ -218,7 +218,7 @@ void RenderWidgetHostViewChildFrame::Focus() {
     return;
   }
   if (frame_connector_->HasFocus() ==
-      CrossProcessFrameConnector::RootViewFocusState::kNotFocused) {
+      CrossProcessFrameConnectorBase::RootViewFocusState::kNotFocused) {
     return frame_connector_->FocusRootView();
   }
 }
@@ -228,7 +228,7 @@ bool RenderWidgetHostViewChildFrame::HasFocus() {
     return false;
   }
   return frame_connector_->HasFocus() ==
-         CrossProcessFrameConnector::RootViewFocusState::kFocused;
+         CrossProcessFrameConnectorBase::RootViewFocusState::kFocused;
 }
 
 bool RenderWidgetHostViewChildFrame::IsSurfaceAvailableForCopy() {
@@ -759,7 +759,7 @@ void RenderWidgetHostViewChildFrame::PreProcessTouchEvent(
     return;
   }
 
-  CrossProcessFrameConnector::RootViewFocusState state =
+  CrossProcessFrameConnectorBase::RootViewFocusState state =
       frame_connector_->HasFocus();
 #if BUILDFLAG(IS_ANDROID)
   UMA_HISTOGRAM_ENUMERATION(
@@ -767,7 +767,8 @@ void RenderWidgetHostViewChildFrame::PreProcessTouchEvent(
       state);
 #endif
 
-  if (state == CrossProcessFrameConnector::RootViewFocusState::kNotFocused) {
+  if (state ==
+      CrossProcessFrameConnectorBase::RootViewFocusState::kNotFocused) {
     Focus();
   }
 }

--- a/content/browser/renderer_host/render_widget_host_view_child_frame.h
+++ b/content/browser/renderer_host/render_widget_host_view_child_frame.h
@@ -42,7 +42,7 @@
 #endif  // BUILDFLAG(IS_MAC)
 
 namespace content {
-class CrossProcessFrameConnector;
+class CrossProcessFrameConnectorBase;
 class RenderWidgetHost;
 class RenderWidgetHostViewChildFrameTest;
 class TouchSelectionControllerClientChildFrame;
@@ -71,7 +71,7 @@ class CONTENT_EXPORT RenderWidgetHostViewChildFrame
   RenderWidgetHostViewChildFrame& operator=(
       const RenderWidgetHostViewChildFrame&) = delete;
 
-  void SetFrameConnector(CrossProcessFrameConnector* frame_connector);
+  void SetFrameConnector(CrossProcessFrameConnectorBase* frame_connector);
 
   // TouchSelectionControllerClientManager::Observer implementation.
   void OnManagerWillDestroy(
@@ -213,7 +213,7 @@ class CONTENT_EXPORT RenderWidgetHostViewChildFrame
   void OnFrameTokenChanged(uint32_t frame_token,
                            base::TimeTicks activation_time) override;
 
-  CrossProcessFrameConnector* FrameConnectorForTesting() const {
+  CrossProcessFrameConnectorBase* FrameConnectorForTesting() const {
     return frame_connector_;
   }
 
@@ -286,7 +286,7 @@ class CONTENT_EXPORT RenderWidgetHostViewChildFrame
 
   // frame_connector_ provides a platform abstraction. Messages
   // sent through it are routed to the embedding renderer process.
-  raw_ptr<CrossProcessFrameConnector> frame_connector_;
+  raw_ptr<CrossProcessFrameConnectorBase> frame_connector_;
 
   base::WeakPtr<RenderWidgetHostViewChildFrame> AsWeakPtr() {
     return weak_factory_.GetWeakPtr();


### PR DESCRIPTION
...instead of CrossProcessFrameConnector. This is basically a trivial change since the base class has everything needed, and is a likely prerequisite of actually using RWHVCF with SecureEmbed.