### PR TITLE
Add `SetFrameSinkId()` to `SecureEmbed` mojo interface and partially implement

### DIFF
--- a/components/secure_embed/browser/secure_embed_host.cc
+++ b/components/secure_embed/browser/secure_embed_host.cc
@@ -93,7 +93,7 @@ void SecureEmbedHost::OnSecureEmbedDisconnected() {
 
 void SecureEmbedHost::SetView(input::RenderWidgetHostViewCore* view,
                               bool allow_paint_holding) {
-  // Detach ourselves from the previous |view_|.
+  // Detach ourselves from the previous `view_`.
   if (view_) {
     input::RenderWidgetHostViewCore* root_view = GetRootRenderWidgetHostView();
     if (root_view && root_view->GetCursorManager()) {
@@ -130,12 +130,10 @@ void SecureEmbedHost::SetView(input::RenderWidgetHostViewCore* view,
     // if (visibility_ != blink::mojom::FrameVisibility::kRenderedInViewport)
     //   OnVisibilityChanged(visibility_);
 
-    // TODO(webium): Set FrameSinkId via mojom.
-    // if (frame_proxy_in_parent_renderer_ &&
-    //     frame_proxy_in_parent_renderer_->is_render_frame_proxy_live()) {
-    //   frame_proxy_in_parent_renderer_->GetAssociatedRemoteFrame()
-    //       ->SetFrameSinkId(view_->GetFrameSinkId(), allow_paint_holding);
-    // }
+    if (secure_embed_) {
+      secure_embed_->SetFrameSinkId(view_->GetFrameSinkId(),
+                                    allow_paint_holding);
+    }
   }
 }
 

--- a/components/secure_embed/common/BUILD.gn
+++ b/components/secure_embed/common/BUILD.gn
@@ -15,4 +15,6 @@ mojom("mojom") {
   disable_variants = true
 
   sources = [ "secure_embed.mojom" ]
+
+  public_deps = [ "//services/viz/public/mojom" ]
 }

--- a/components/secure_embed/common/secure_embed.mojom
+++ b/components/secure_embed/common/secure_embed.mojom
@@ -4,8 +4,18 @@
 
 module secure_embed.mojom;
 
+import "services/viz/public/mojom/compositing/frame_sink_id.mojom";
+
 // Implemented in Renderer by SecureEmbedWebPlugin.
 interface SecureEmbed {
+  // Notifies the renderer process that its associated compositing
+  // destination (RenderWidgetHostView) has changed.
+  //
+  // The embedder can keep using the painted content from the previous frame
+  // sink until the new frame sink produces a new frame, i.e., paint holding.
+  // `allow_paint_holding` is used to limit this to same-origin navigations.
+  SetFrameSinkId(viz.mojom.FrameSinkId frame_sink_id, bool allow_paint_holding);
+
   // TODO(secure-embed): Temporary - remove when there's a real SecureEmbed
   // method to call. This is here to verify that the mojo connection is set up
   // correctly and that the browser can call back into the renderer.

--- a/components/secure_embed/renderer/secure_embed_web_plugin.cc
+++ b/components/secure_embed/renderer/secure_embed_web_plugin.cc
@@ -139,6 +139,22 @@ void SecureEmbedWebPlugin::DidFailLoading(const blink::WebURLError& error) {
   NOTIMPLEMENTED();
 }
 
+void SecureEmbedWebPlugin::SetFrameSinkId(const viz::FrameSinkId& frame_sink_id,
+                                          bool allow_paint_holding) {
+  // TODO(webium): This should only be called when the remote process is alive;
+  // should we keep track of this with a boolean, e.g. ` remote_process_gone_`,
+  // like RemoteFrame does?
+
+  frame_sink_id_ = frame_sink_id;
+
+  // TODO(webium): Synchronize visual properties.
+  // SynchronizeVisualProperties(
+  //     /*propagate=*/true,
+  //     allow_paint_holding
+  //         ? ChildFrameCompositingHelper::AllowPaintHolding::kYes
+  //         : ChildFrameCompositingHelper::AllowPaintHolding::kNo);
+}
+
 void SecureEmbedWebPlugin::OnAttached() {
   // TODO(secure-embed): Here for testing only. Remove when there's a real
   // SecureEmbed method to implement.

--- a/components/secure_embed/renderer/secure_embed_web_plugin.h
+++ b/components/secure_embed/renderer/secure_embed_web_plugin.h
@@ -7,6 +7,7 @@
 
 #include "base/memory/raw_ptr.h"
 #include "components/secure_embed/common/secure_embed.mojom.h"
+#include "components/viz/common/surfaces/frame_sink_id.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
 #include "third_party/blink/public/web/web_plugin.h"
@@ -54,6 +55,8 @@ class SecureEmbedWebPlugin : public blink::WebPlugin,
   void DidFailLoading(const blink::WebURLError& error) override;
 
   // mojom::SecureEmbed:
+  void SetFrameSinkId(const viz::FrameSinkId& frame_sink_id,
+                      bool allow_paint_holding) override;
   void OnAttached() override;
 
  private:
@@ -65,6 +68,8 @@ class SecureEmbedWebPlugin : public blink::WebPlugin,
 
   // The guest contents ID parsed from the `data-content-id` attribute.
   int contents_id_ = -1;
+
+  viz::FrameSinkId frame_sink_id_;
 
   raw_ptr<blink::WebPluginContainer> container_ = nullptr;
 


### PR DESCRIPTION
This PR depends on #22 . 

Here we add `SetFrameSinkId()` to the `SecureEmbed` mojo interface and partially implement it in  `SecureEmbedWebPlugin` so that we can call it in `SecureEmbedHost::SetView()`. 