### PR TITLE
Update copyright year to 2025; fix typo

### DIFF
--- a/content/public/browser/secure_embed_delegate.h
+++ b/content/public/browser/secure_embed_delegate.h
@@ -1,4 +1,4 @@
-// Copyright 2013 The Chromium Authors
+// Copyright 2025 The Chromium Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -12,7 +12,7 @@
 namespace content {
 
 // Implementations of this class are passed to WebContents that are going to be
-// embedded via SecureEmebed, to help them communicate with their embedder.
+// embedded via SecureEmbed, to help them communicate with their embedder.
 //
 // TODO(secure-embed): If this remains this simple, we may want to replace it
 // with just passing a WebContents*.


### PR DESCRIPTION
Updated copyright year in secure_embed_delegate.h and fixed typo.