### PR TITLE
Fix components_browsertests compile

### DIFF
--- a/components/secure_embed/browser/secure_embed_web_plugin_browsertest.cc
+++ b/components/secure_embed/browser/secure_embed_web_plugin_browsertest.cc
@@ -120,6 +120,11 @@ class MockSecureEmbedHost : public mojom::SecureEmbedHost {
   void SynchronizeVisualProperties(
       const blink::FrameVisualProperties& visual_properties) override {}
 
+  void DispatchKeyboardEvent(
+      std::unique_ptr<blink::WebCoalescedInputEvent> key_event) override {}
+
+  void SetFocus(bool focused, blink::mojom::FocusType focus_type) override {}
+
   void OnSecureEmbedDisconnected() { secure_embed_.reset(); }
 
   void SetAttachCallback(base::OnceCallback<void(int64_t)> callback) {


### PR DESCRIPTION
Define DispatchKeyboardEvent and SetFocus on MockSecureEmbedHost.