### PR TITLE
Compile Fix: Implement missing virtual methods in `MockSecureEmbedHost`

### DIFF
--- a/components/secure_embed/browser/secure_embed_web_plugin_browsertest.cc
+++ b/components/secure_embed/browser/secure_embed_web_plugin_browsertest.cc
@@ -120,6 +120,10 @@ class MockSecureEmbedHost : public mojom::SecureEmbedHost {
   void SynchronizeVisualProperties(
       const blink::FrameVisualProperties& visual_properties) override {}
 
+  void DispatchKeyboardEvent(
+      std::unique_ptr<blink::WebCoalescedInputEvent> key_event) override {}
+  void SetFocus(bool focused, blink::mojom::FocusType focus_type) override {}
+
   void OnSecureEmbedDisconnected() { secure_embed_.reset(); }
 
   void SetAttachCallback(base::OnceCallback<void(int64_t)> callback) {


### PR DESCRIPTION
We add empty implementations for the `DispatchKeyboardEvent()` and `SetFocus()` pure virtual methods in the MockSecureEmbedHost class. This resolves a compilation error where the mock class was instantiated without providing implementations for these methods, which are required by the `mojom::SecureEmbedHost` interface.