### PR TITLE
[cherry-pick] [webui browser] Fix null deref in toolbar button update

### DIFF
--- a/chrome/browser/ui/webui_browser/webui_browser_page_handler.cc
+++ b/chrome/browser/ui/webui_browser/webui_browser_page_handler.cc
@@ -61,6 +61,10 @@ class WebUIBrowserGuestHandler
   }
 
   void CanGoBack(CanGoBackCallback callback) override {
+    if (!web_contents_.get()) {
+      std::move(callback).Run(/*can_go_back=*/false);
+      return;
+    }
     std::move(callback).Run(web_contents_->GetController().CanGoBack());
   }
 
@@ -71,6 +75,10 @@ class WebUIBrowserGuestHandler
   }
 
   void CanGoForward(CanGoForwardCallback callback) override {
+    if (!web_contents_.get()) {
+      std::move(callback).Run(/*can_go_forward=*/false);
+      return;
+    }
     std::move(callback).Run(web_contents_->GetController().CanGoForward());
   }
 


### PR DESCRIPTION
This is a cherry-pick of https://crrev.com/c/6960370 by @pythagoraskitty .

From local crash stack traces, it seems that that web_contents_ weak pointer in WebUIBrowserGuestHandler can sometimes be null when a tab strip model change causes a recalculation of whether the back and/or forward buttons should be available.

I am able to reproduce this bug by opening several different tabs with varying contents and closing some of them, reopening, switching focus between tabs, until a crash happens due to
"FATAL:base/memory/weak_ptr.h:250] Check failed: ref_.IsValid()", with a stack trace that has WebUIBrowserGuestHandler::CanGoBack() just before the Check error.

Bug: 393144165
Change-Id: Ia57c47159d96ada5a3345d4e09e32b02825c2c5f
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6960370
Commit-Queue: Cammie Smith Barnes <cammie@chromium.org>
Reviewed-by: Keren Zhu <kerenzhu@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1516758}