### PR TITLE
Fix blank page after closing tab

### DIFF
--- a/chrome/browser/resources/webui_browser/webview.ts
+++ b/chrome/browser/resources/webui_browser/webview.ts
@@ -67,7 +67,7 @@ export class WebviewElement extends CrLitElement {
 
   setActive(active: boolean) {
     this.active = active;
-    if (this.attached) {
+    if (this.attached && active) {
       this.$.embed.focus();
     }
   }


### PR DESCRIPTION
On tab closing, the old `<cr-tab-webview>` is detached and then `this.$.focus()` is called. This triggers an assertion in CrLitElement that says the element proxy (i.e., `CrLitElement.$`) should not be used on detached element. The assertion stops JS execution, resulting in blank page. This PR fixes that by not calling `focus()` on tab deactivation.