### PR TITLE
Fix initial loop in visual properties update

### DIFF
--- a/content/browser/secure_embed_connector_impl.cc
+++ b/content/browser/secure_embed_connector_impl.cc
@@ -374,7 +374,7 @@ void SecureEmbedConnectorImpl::DidUpdateVisualProperties(
     const cc::RenderFrameMetadata& metadata) {
   if (metadata.local_surface_id.has_value() &&
       local_surface_id_ != *metadata.local_surface_id) {
-    // `local_surface_id_` will be updated in OnSynchronizeVisualProperties()
+    // `local_surface_id_` will be updated in SynchronizeVisualProperties()
     // after a round-trip to the Plugin.
     delegate_->UpdateLocalSurfaceIdFromChild(
         *metadata.local_surface_id);


### PR DESCRIPTION
This PR fixes an infinite loop due to visual properties update. The loop is

- The Plugin sends local surface id to the browser via `SecureEmbedHost::SynchronizeVisualProperties()`. 
- On the browser, `SecureEmbedConnectorImpl::DidUpdateVisualProperties()` is called due to render frame metadata changes.
- The Plugin's `SecureEmbedWebPlugin::UpdateLocalSurfaceIdFromChild()` is called.
- A new local surface id is generated, then `SecureEmbedHost::SynchronizeVisualProperties()` is called again. 

The PR fixes it by sending mojo call to Plugin only if the local surface id actually changes.