### PR TITLE
Compile Fix: Update `MockSecureEmbedHost` to match mojom interface

### DIFF
--- a/components/secure_embed/browser/secure_embed_web_plugin_browsertest.cc
+++ b/components/secure_embed/browser/secure_embed_web_plugin_browsertest.cc
@@ -118,7 +118,8 @@ class MockSecureEmbedHost : public mojom::SecureEmbedHost {
   }
 
   void SynchronizeVisualProperties(
-      const blink::FrameVisualProperties& visual_properties) override {}
+      const blink::FrameVisualProperties& visual_properties,
+      bool is_visible) override {}
 
   void DispatchKeyboardEvent(
       std::unique_ptr<blink::WebCoalescedInputEvent> key_event) override {}


### PR DESCRIPTION
We update `SynchronizeVisualProperties()` method in `MockSecureEmbedHost`  to  include the `is_visible` parameter. This change aligns the mock implementation with the `mojom::SecureEmbedHost` interface, resolving a compilation error caused by a mismatch in function signatures.