### PR TITLE
Propagate visibility changes across embed boundaries

### DIFF
--- a/components/secure_embed/browser/secure_embed_browsertest.cc
+++ b/components/secure_embed/browser/secure_embed_browsertest.cc
@@ -9,6 +9,8 @@
 #include "components/guest_contents/browser/guest_contents_handle.h"
 #include "components/secure_embed/browser/secure_embed_host.h"
 #include "content/public/browser/browser_context.h"
+#include "content/public/browser/render_widget_host.h"
+#include "content/public/browser/render_widget_host_observer.h"
 #include "content/public/browser/render_widget_host_view.h"
 #include "content/public/browser/secure_embed_connector.h"
 #include "content/public/browser/web_contents.h"
@@ -26,6 +28,48 @@ namespace {
 constexpr char kEmbedTagTestUrl[] = "/secure_embed/embed_tag.html";
 constexpr char kAttachHarnessUrl[] =
     "/secure_embed/single_embed_attach_harness.html";
+
+// Observer that waits for a RenderWidgetHost visibility change.
+class RenderWidgetHostVisibilityWaiter
+    : public content::RenderWidgetHostObserver {
+ public:
+  RenderWidgetHostVisibilityWaiter(content::RenderWidgetHost* rwh,
+                                   bool expected_visibility)
+      : expected_visibility_(expected_visibility) {
+    rwh->AddObserver(this);
+    rwh_ = rwh;
+  }
+
+  ~RenderWidgetHostVisibilityWaiter() override { rwh_->RemoveObserver(this); }
+
+  void Wait() {
+    if (!satisfied_) {
+      run_loop_.Run();
+    }
+  }
+
+  // RenderWidgetHostObserver:
+  void RenderWidgetHostVisibilityChanged(content::RenderWidgetHost* widget_host,
+                                         bool became_visible) override {
+    if (became_visible == expected_visibility_) {
+      satisfied_ = true;
+      run_loop_.Quit();
+    }
+  }
+
+  void RenderWidgetHostDestroyed(
+      content::RenderWidgetHost* widget_host) override {
+    rwh_->RemoveObserver(this);
+    rwh_ = nullptr;
+  }
+
+ private:
+  bool expected_visibility_;
+  bool satisfied_ = false;
+  base::RunLoop run_loop_;
+  raw_ptr<content::RenderWidgetHost> rwh_ = nullptr;
+};
+
 }  // namespace
 
 class SecureEmbedBrowserTest : public content::ContentBrowserTest {
@@ -134,10 +178,12 @@ class SecureEmbedBrowserTest : public content::ContentBrowserTest {
   }
 
   // Create a guest WebContents configured for secure embed.
-  std::unique_ptr<content::WebContents> CreateGuestWebContents() {
+  std::unique_ptr<content::WebContents> CreateGuestWebContents(
+      content::WebContents* embedder = nullptr) {
     content::WebContents::CreateParams create_params(
         shell()->web_contents()->GetBrowserContext());
-    create_params.secure_embed_embedder = shell()->web_contents();
+    create_params.secure_embed_embedder =
+        embedder ? embedder : shell()->web_contents();
     std::unique_ptr<content::WebContents> guest_contents =
         content::WebContents::Create(create_params);
     EXPECT_NE(guest_contents, nullptr);
@@ -283,6 +329,144 @@ IN_PROC_BROWSER_TEST_F(SecureEmbedBrowserTest, VisibilityHiddenStopsRendering) {
       web_contents(),
       "document.querySelector('embed').style.visibility = 'visible';"));
   VerifyBoxRendering(SK_ColorRED);
+}
+
+IN_PROC_BROWSER_TEST_F(SecureEmbedBrowserTest, TabSwitchingUpdatesVisibility) {
+  // This test simulates a tab switch by changing the visibility of the top-
+  // level WebContents. The secure embed guest should receive visibility
+  // updates accordingly. This is similar to SitePerProcessBrowserTest::
+  // TabSwitchingUpdatesVisibility.
+
+  auto guest_contents =
+      SetupHarnessAndGuestWithContent("/secure_embed/red_box.html");
+  AttachGuestToEmbed(guest_contents.get());
+
+  VerifyBoxRendering(SK_ColorRED);
+
+  content::RenderFrameHost* guest_frame = guest_contents->GetPrimaryMainFrame();
+  auto* guest_rwh = guest_frame->GetRenderWidgetHost();
+  ASSERT_NE(guest_rwh, nullptr);
+  EXPECT_TRUE(guest_rwh->GetView()->IsShowing());
+
+  // Simulate tab switch away (hide) and back (show), verifying guest
+  // visibility.
+  {
+    RenderWidgetHostVisibilityWaiter waiter(guest_rwh, false);
+    web_contents()->WasHidden();
+    waiter.Wait();
+    EXPECT_FALSE(guest_rwh->GetView()->IsShowing());
+  }
+
+  {
+    RenderWidgetHostVisibilityWaiter waiter(guest_rwh, true);
+    web_contents()->WasShown();
+    waiter.Wait();
+    EXPECT_TRUE(guest_rwh->GetView()->IsShowing());
+  }
+
+  VerifyBoxRendering(SK_ColorRED);
+}
+
+IN_PROC_BROWSER_TEST_F(SecureEmbedBrowserTest,
+                       VisibilityCrossesSurfaceEmbedBoundary) {
+  // This test creates a nested structure using secure embeds to verify that
+  // visibility changes propagate through multiple embedding levels. When
+  // visibility of the outermost embed is set to hidden, both the middle and
+  // inner guests should report themselves as hidden. This test goes from
+  // visible to hidden and back to visible, verifying the visibility state at
+  // each step.
+
+  // Navigate the parent page to the attach harness.
+  GURL parent_url = embedded_test_server()->GetURL(
+      "/secure_embed/single_embed_attach_harness.html");
+  ASSERT_TRUE(NavigateToURL(web_contents(), parent_url));
+
+  // Create the middle guest and set up its embed for the inner guest.
+  auto middle_guest = CreateGuestWebContents();
+  GURL middle_url = embedded_test_server()->GetURL(
+      "/secure_embed/single_embed_attach_harness.html");
+  ASSERT_TRUE(NavigateToURL(middle_guest.get(), middle_url));
+  ASSERT_TRUE(content::WaitForLoadStop(middle_guest.get()));
+
+  // Create the innermost guest.
+  auto inner_guest = CreateGuestWebContents(middle_guest.get());
+  GURL inner_url = embedded_test_server()->GetURL("/secure_embed/red_box.html");
+  ASSERT_TRUE(NavigateToURL(inner_guest.get(), inner_url));
+  ASSERT_TRUE(content::WaitForLoadStop(inner_guest.get()));
+
+  int inner_guest_id = GetGuestHandleId(inner_guest.get());
+  int middle_guest_id = GetGuestHandleId(middle_guest.get());
+
+  // Attach the middle guest to the parent's embed element.
+  std::string attach_middle_script =
+      "createEmbed(" + base::NumberToString(middle_guest_id) + ");";
+  ASSERT_TRUE(content::ExecJs(web_contents(), attach_middle_script));
+  ASSERT_TRUE(WaitForHostCreation(1));
+
+  // Attach the inner guest to the middle guest's embed element.
+  std::string attach_inner_script =
+      "createEmbed(" + base::NumberToString(inner_guest_id) + ");";
+  ASSERT_TRUE(content::ExecJs(middle_guest.get(), attach_inner_script));
+  ASSERT_TRUE(WaitForHostCreation(2));
+
+  content::RenderFrameHost* parent_frame =
+      web_contents()->GetPrimaryMainFrame();
+  content::RenderFrameHost* middle_frame = middle_guest->GetPrimaryMainFrame();
+  content::RenderFrameHost* inner_frame = inner_guest->GetPrimaryMainFrame();
+
+  auto* parent_rwh = parent_frame->GetRenderWidgetHost();
+  auto* middle_rwh = middle_frame->GetRenderWidgetHost();
+  auto* inner_rwh = inner_frame->GetRenderWidgetHost();
+
+  // Verify all frames are initially visible.
+  EXPECT_TRUE(parent_rwh->GetView()->IsShowing());
+  EXPECT_TRUE(middle_rwh->GetView()->IsShowing());
+  EXPECT_TRUE(inner_rwh->GetView()->IsShowing());
+
+  VerifyBoxRendering(SK_ColorRED);
+
+  // Transition to hidden.
+  {
+    // Create visibility observers for the guest frames to detect when they
+    // become hidden.
+    RenderWidgetHostVisibilityWaiter middle_waiter(middle_rwh, false);
+    RenderWidgetHostVisibilityWaiter inner_waiter(inner_rwh, false);
+
+    // Hide the embed element in the parent, which should propagate to all
+    // nested guests.
+    ASSERT_TRUE(content::ExecJs(
+        web_contents(),
+        "document.querySelector('embed').style.visibility = 'hidden';"));
+
+    middle_waiter.Wait();
+    inner_waiter.Wait();
+
+    // Verify all guest frames are now hidden.
+    EXPECT_TRUE(parent_rwh->GetView()->IsShowing());
+    EXPECT_FALSE(middle_rwh->GetView()->IsShowing());
+    EXPECT_FALSE(inner_rwh->GetView()->IsShowing());
+  }
+
+  // Transition to visible.
+  {
+    // Create visibility observers for the guest frames to detect when they
+    // become visible again.
+    RenderWidgetHostVisibilityWaiter middle_waiter(middle_rwh, true);
+    RenderWidgetHostVisibilityWaiter inner_waiter(inner_rwh, true);
+
+    // Show the embed element again.
+    ASSERT_TRUE(content::ExecJs(
+        web_contents(),
+        "document.querySelector('embed').style.visibility = 'visible';"));
+
+    middle_waiter.Wait();
+    inner_waiter.Wait();
+
+    // Verify all frames are visible again.
+    EXPECT_TRUE(parent_rwh->GetView()->IsShowing());
+    EXPECT_TRUE(middle_rwh->GetView()->IsShowing());
+    EXPECT_TRUE(inner_rwh->GetView()->IsShowing());
+  }
 }
 
 IN_PROC_BROWSER_TEST_F(SecureEmbedBrowserTest, DisplayNoneStopsRendering) {

--- a/components/secure_embed/browser/secure_embed_host.cc
+++ b/components/secure_embed/browser/secure_embed_host.cc
@@ -116,6 +116,14 @@ void SecureEmbedHost::SynchronizeVisualProperties(
   }
 }
 
+void SecureEmbedHost::SetVisibility(bool is_visible) {
+  if (content::SecureEmbedConnector* connector = GetConnector()) {
+    connector->OnVisibilityChanged(
+        is_visible ? blink::mojom::FrameVisibility::kRenderedInViewport
+                   : blink::mojom::FrameVisibility::kNotRendered);
+  }
+}
+
 void SecureEmbedHost::SetFocus(bool focused,
                                blink::mojom::FocusType focus_type) {
   know_have_focus_ = false;
@@ -177,6 +185,13 @@ void SecureEmbedHost::FocusInEmbedder(
   }
 
   secure_embed_->RequestFocus(mojo_focus_op);
+}
+
+void SecureEmbedHost::EmbedderVisibilityChanged(
+    content::Visibility visibility) {
+  // TODO(secure-embed): Content visibility could also be OCCLUDED. Need to
+  // determine how that maps.
+  SetVisibility(visibility == content::Visibility::VISIBLE);
 }
 
 content::RenderFrameHost* SecureEmbedHost::ParentFrame() {

--- a/components/secure_embed/browser/secure_embed_host.h
+++ b/components/secure_embed/browser/secure_embed_host.h
@@ -9,6 +9,7 @@
 #include "base/memory/weak_ptr.h"
 #include "components/secure_embed/common/secure_embed.mojom.h"
 #include "content/public/browser/secure_embed_connector.h"
+#include "content/public/browser/visibility.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
 #include "mojo/public/cpp/bindings/pending_associated_receiver.h"
 #include "mojo/public/cpp/bindings/self_owned_associated_receiver.h"
@@ -48,6 +49,7 @@ class COMPONENT_EXPORT(SECURE_EMBED) SecureEmbedHost
   void SynchronizeVisualProperties(
       const blink::FrameVisualProperties& visual_properties,
       bool is_visible) override;
+  void SetVisibility(bool is_visible) override;
   void SetFocus(bool focused, blink::mojom::FocusType focus_type) override;
 
   // content::SecureEmbedConnector::Delegate implementation:
@@ -56,6 +58,7 @@ class COMPONENT_EXPORT(SECURE_EMBED) SecureEmbedHost
       const ::viz::LocalSurfaceId& local_surface_id) override;
   void FocusInEmbedder(
       content::SecureEmbedConnector::FocusOperation focus_op) override;
+  void EmbedderVisibilityChanged(content::Visibility visibility) override;
   content::RenderFrameHost* ParentFrame() override;
 
  private:

--- a/components/secure_embed/browser/secure_embed_web_plugin_browsertest.cc
+++ b/components/secure_embed/browser/secure_embed_web_plugin_browsertest.cc
@@ -121,6 +121,8 @@ class MockSecureEmbedHost : public mojom::SecureEmbedHost {
       const blink::FrameVisualProperties& visual_properties,
       bool is_visible) override {}
 
+  void SetVisibility(bool is_visible) override {}
+
   void SetFocus(bool focused, blink::mojom::FocusType focus_type) override {}
 
   void OnSecureEmbedDisconnected() { secure_embed_.reset(); }

--- a/components/secure_embed/common/secure_embed.mojom
+++ b/components/secure_embed/common/secure_embed.mojom
@@ -44,6 +44,9 @@ interface SecureEmbedHost {
   SynchronizeVisualProperties(blink.mojom.FrameVisualProperties visual_properties,
                               bool is_visible);
 
+  // Notifies that the visibility of the plugin has changed.
+  SetVisibility(bool is_visible);
+
   // Notifies that the plugin either gained or lost focus.
   SetFocus(bool focused, blink.mojom.FocusType focus_type);
 };

--- a/components/secure_embed/renderer/secure_embed_web_plugin.cc
+++ b/components/secure_embed/renderer/secure_embed_web_plugin.cc
@@ -273,7 +273,15 @@ void SecureEmbedWebPlugin::UpdateFocus(bool focused,
   host_->SetFocus(focused, focus_type);
 }
 
-void SecureEmbedWebPlugin::UpdateVisibility(bool is_visible) {}
+void SecureEmbedWebPlugin::UpdateVisibility(bool is_visible) {
+  // Note that visibility could be different than the plugin is aware if the
+  // embedder WebContents is not visible.
+  if (last_is_visible_ == is_visible) {
+    return;
+  }
+  last_is_visible_ = is_visible;
+  host_->SetVisibility(last_is_visible_);
+}
 
 blink::WebInputEventResult SecureEmbedWebPlugin::HandleInputEvent(
     const blink::WebCoalescedInputEvent& coalesced_event,

--- a/content/browser/secure_embed_connector_impl.cc
+++ b/content/browser/secure_embed_connector_impl.cc
@@ -33,19 +33,38 @@ namespace content {
 // Nested observer class that forwards relevant events to
 // SecureEmbedConnectorImpl. This avoids function name collisions with
 // CrossProcessFrameConnectorBase.
-class SecureEmbedConnectorImpl::WCObserver : public WebContentsObserver {
+class SecureEmbedConnectorImpl::EmbeddedWebContentsObserver
+    : public WebContentsObserver {
  public:
-  explicit WCObserver(SecureEmbedConnectorImpl* guest_frame,
-                      WebContents* web_contents)
-      : WebContentsObserver(web_contents), guest_frame_(guest_frame) {}
+  explicit EmbeddedWebContentsObserver(SecureEmbedConnectorImpl* connector,
+                                       WebContents* web_contents)
+      : WebContentsObserver(web_contents), connector_(connector) {}
 
-  ~WCObserver() override = default;
+  ~EmbeddedWebContentsObserver() override = default;
 
   // WebContentsObserver:
-  void RenderViewReady() override { guest_frame_->OnRenderViewReady(); }
+  void RenderViewReady() override { connector_->OnRenderViewReady(); }
 
  private:
-  raw_ptr<SecureEmbedConnectorImpl> guest_frame_;
+  raw_ptr<SecureEmbedConnectorImpl> connector_;
+};
+
+class SecureEmbedConnectorImpl::EmbedderWebContentsObserver
+    : public WebContentsObserver {
+ public:
+  explicit EmbedderWebContentsObserver(SecureEmbedConnectorImpl* connector,
+                                       WebContents* web_contents)
+      : WebContentsObserver(web_contents), connector_(connector) {}
+
+  ~EmbedderWebContentsObserver() override = default;
+
+  // WebContentsObserver:
+  void OnVisibilityChanged(Visibility visibility) override {
+    connector_->EmbedderVisibilityChanged(visibility);
+  }
+
+ private:
+  raw_ptr<SecureEmbedConnectorImpl> connector_;
 };
 
 SecureEmbedConnectorImpl::SecureEmbedConnectorImpl(
@@ -53,7 +72,10 @@ SecureEmbedConnectorImpl::SecureEmbedConnectorImpl(
     WebContentsImpl* embedded_web_contents)
     : embedder_web_contents_(embedder_web_contents->GetWeakPtr()),
       guest_web_contents_(embedded_web_contents) {
-  observer_ = std::make_unique<WCObserver>(this, embedded_web_contents);
+  embedded_observer_ = std::make_unique<EmbeddedWebContentsObserver>(
+      this, embedded_web_contents);
+  embedder_observer_ = std::make_unique<EmbedderWebContentsObserver>(
+      this, embedder_web_contents);
 
   // TODO(secure-embed): There may not be a view yet, depending on if the
   // WebContents has been shown or navigated. That means calling GetScreenInfos
@@ -506,6 +528,11 @@ void SecureEmbedConnectorImpl::OnSetInheritedEffectiveTouchAction(
 
 void SecureEmbedConnectorImpl::OnVisibilityChanged(
     blink::mojom::FrameVisibility visibility) {
+  // Visibility changes can come from multiple sources. The embedding
+  // WebContents can update its visibility state which needs propagated to the
+  // embedded WebContents. Similarly, any element in the embedder WebContents
+  // that contains the embedded WebContents can also change visibility state,
+  // from the root to the <embed> (inclusive).
   bool visible = visibility != blink::mojom::FrameVisibility::kNotRendered;
   visibility_ = visibility;
 
@@ -600,11 +627,6 @@ Visibility SecureEmbedConnectorImpl::EmbedderVisibility() {
     return Visibility::HIDDEN;
   }
 
-  // TODO(secure-embed): Need to get the embedder visibility rather than the
-  // embedded visibility. Embedder = SecureEmbed. May need to add a method to
-  // SecureEmbedDelegate for this or ensure that visibility state is pushed to
-  // the GuestFrame when it changes.
-  NOTIMPLEMENTED();
   return embedder_web_contents_->GetVisibility();
 }
 
@@ -647,6 +669,17 @@ input::RenderWidgetHostViewInput* SecureEmbedConnectorImpl::GetRootViewInput() {
 void SecureEmbedConnectorImpl::OnRenderViewReady() {
   // When the RenderView is ready, update the view in case it has changed.
   UpdateViewForCurrentRenderFrameHost();
+}
+
+void SecureEmbedConnectorImpl::EmbedderVisibilityChanged(
+    content::Visibility visibility) {
+  // When the embedder visibility changes, we may need to update the embedded
+  // visibility as well. Changes in the visibility at the embedder WebContents
+  // level don't automatically show up as a visibility change at the embed/
+  // plugin level.
+  if (delegate_) {
+    delegate_->EmbedderVisibilityChanged(visibility);
+  }
 }
 
 void SecureEmbedConnectorImpl::UpdateViewForCurrentRenderFrameHost() {

--- a/content/browser/secure_embed_connector_impl.h
+++ b/content/browser/secure_embed_connector_impl.h
@@ -135,11 +135,13 @@ class SecureEmbedConnectorImpl : public SecureEmbedConnector,
   input::RenderWidgetHostViewInput* GetRootViewInput() override;
 
   void OnRenderViewReady();
+  void EmbedderVisibilityChanged(content::Visibility visibility);
 
  private:
   // Forward decl for internal observer that tracks WebContents events and
   // forwards them to this class.
-  class WCObserver;
+  class EmbeddedWebContentsObserver;
+  class EmbedderWebContentsObserver;
 
   // Resets the rect and the viz::LocalSurfaceId of the connector to ensure the
   // unguessable surface ID is not reused after a cross-process navigation.
@@ -158,7 +160,8 @@ class SecureEmbedConnectorImpl : public SecureEmbedConnector,
   // for GuestFrameImpl to get the RenderFrameHost from the guest WebContents.
   RenderFrameHostImpl* current_child_frame_host() const;
 
-  std::unique_ptr<WCObserver> observer_;
+  std::unique_ptr<EmbeddedWebContentsObserver> embedded_observer_;
+  std::unique_ptr<EmbedderWebContentsObserver> embedder_observer_;
   raw_ptr<SecureEmbedConnector::Delegate> delegate_ = nullptr;
 
   base::WeakPtr<WebContents> embedder_web_contents_;

--- a/content/public/browser/secure_embed_connector.h
+++ b/content/public/browser/secure_embed_connector.h
@@ -9,6 +9,7 @@
 #include "components/viz/common/surfaces/frame_sink_id.h"
 #include "components/viz/common/surfaces/local_surface_id.h"
 #include "content/common/content_export.h"
+#include "content/public/browser/visibility.h"
 #include "third_party/blink/public/common/input/web_keyboard_event.h"
 #include "third_party/blink/public/mojom/frame/lifecycle.mojom.h"
 #include "third_party/blink/public/mojom/input/focus_type.mojom.h"
@@ -43,6 +44,9 @@ class CONTENT_EXPORT SecureEmbedConnector {
     // Requests focus in the embedder document for either the embedding element,
     // or the elements before or after it in the tab order, based on `focus_op`.
     virtual void FocusInEmbedder(FocusOperation focus_op) = 0;
+
+    // Notifies the delegate that the embedder's visibility has changed.
+    virtual void EmbedderVisibilityChanged(content::Visibility visibility) = 0;
 
     // Returns the exact frame the contents is embedded in.
     virtual RenderFrameHost* ParentFrame() = 0;


### PR DESCRIPTION
This CL enables visibility state to properly propagate from embedder WebContents to embedded secure embed guests, including across nested embedding scenarios. Previously, changes to embedder visibility (e.g., tab switching) did not reach the embedded content.

Key changes:
- Add EmbedderVisibilityChanged() to SecureEmbedConnector::Delegate to notify guests when the embedder's visibility state changes. This covers the scenario where the entire embedding WebContents is hidden.
- Implement SetVisibility() in SecureEmbedHost and SecureEmbedWebPlugin to handle visibility updates independently of visual property syncs. This handles scenarios such as setting visibility: hidden on the embed element and ensuring that state gets propagated to the attached guest.

Added tests to cover these scenarios:
- Add TabSwitchingUpdatesVisibility test to verify guest visibility updates when embedder WebContents visibility changes.
- Add VisibilityCrossesSurfaceEmbedBoundary test with nested A->B->A structure to verify visibility propagates through multiple embedding levels, including visibility changes directly on the embed are propagated.