### PR TITLE
Use GlobalRenderFrameHostId instead of RFH raw_ptr

### DIFF
--- a/components/secure_embed/browser/secure_embed_host.cc
+++ b/components/secure_embed/browser/secure_embed_host.cc
@@ -23,7 +23,7 @@ namespace secure_embed {
 size_t SecureEmbedHost::instance_count_for_testing_ = 0;
 
 SecureEmbedHost::SecureEmbedHost(content::RenderFrameHost* render_frame_host)
-    : render_frame_host_(render_frame_host), secure_embed_() {
+    : render_frame_host_id_(render_frame_host->GetGlobalId()), secure_embed_() {
   ++instance_count_for_testing_;
 }
 
@@ -88,7 +88,7 @@ void SecureEmbedHost::Attach(int64_t content_id) {
 
   if (!web_contents_to_attach->GetSecureEmbedConnector()
            ->IsConfiguredToBeEmbeddedIn(
-               content::WebContents::FromRenderFrameHost(render_frame_host_))) {
+               content::WebContents::FromRenderFrameHost(ParentFrame()))) {
     LOG(ERROR) << "WebContents not configured to embed here";
     return;
   }
@@ -180,7 +180,7 @@ void SecureEmbedHost::FocusInEmbedder(
 }
 
 content::RenderFrameHost* SecureEmbedHost::ParentFrame() {
-  return render_frame_host_;
+  return content::RenderFrameHost::FromID(render_frame_host_id_);
 }
 
 content::SecureEmbedConnector* SecureEmbedHost::GetConnector() {

--- a/components/secure_embed/browser/secure_embed_host.h
+++ b/components/secure_embed/browser/secure_embed_host.h
@@ -8,6 +8,7 @@
 #include "base/component_export.h"
 #include "base/memory/weak_ptr.h"
 #include "components/secure_embed/common/secure_embed.mojom.h"
+#include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/secure_embed_connector.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
 #include "mojo/public/cpp/bindings/pending_associated_receiver.h"
@@ -69,7 +70,7 @@ class COMPONENT_EXPORT(SECURE_EMBED) SecureEmbedHost
   // Count of all alive instances for testing.
   static size_t instance_count_for_testing_;
 
-  raw_ptr<content::RenderFrameHost> render_frame_host_ = nullptr;
+  content::GlobalRenderFrameHostId render_frame_host_id_;
   base::WeakPtr<content::WebContents> guest_contents_ = nullptr;
   bool know_have_focus_ = false;
 


### PR DESCRIPTION
Replace raw_ptr<RenderFrameHost> with GlobalRenderFrameHostId in SecureEmbedHost to avoid storing a raw pointer to a RenderFrameHost. This avoids dangling pointer issues when the RFH is destroyed down before the mojom connection teardown from the plugin causes the SecureEmbedHost to be destroyed.

After this change, the browsertests can be ran without failing due to dangling ptrs.