### PR TITLE
Restrict SurfaceEmbed to chrome://webui-browser

### DIFF
--- a/chrome/renderer/chrome_content_renderer_client.cc
+++ b/chrome/renderer/chrome_content_renderer_client.cc
@@ -343,6 +343,16 @@ std::unique_ptr<base::Unwinder> CreateV8Unwinder(v8::Isolate* isolate) {
   return std::make_unique<V8Unwinder>(isolate);
 }
 
+// Allows only chrome://webui-browser to use SurfaceEmbed,
+// i.e., <embed type="application/x-chromium-surface-embed">.
+bool IsSurfaceEmbedAllowedInFrame(content::RenderFrame* render_frame) {
+  CHECK(render_frame);
+  const url::Origin webui_browser_origin =
+      url::Origin::Create(GURL(chrome::kChromeUIWebuiBrowserURL));
+  return url::Origin::Create(render_frame->GetWebFrame()->GetDocument().Url())
+      .IsSameOriginWith(webui_browser_origin);
+}
+
 }  // namespace
 
 ChromeContentRendererClient::ChromeContentRendererClient()
@@ -898,8 +908,10 @@ bool ChromeContentRendererClient::OverrideCreatePlugin(
 #endif
 
 #if BUILDFLAG(ENABLE_SECURE_EMBED)
-  if (secure_embed::MaybeCreatePlugin(render_frame, params, plugin)) {
-    return true;
+  if (IsSurfaceEmbedAllowedInFrame(render_frame)) {
+    if (secure_embed::MaybeCreatePlugin(render_frame, params, plugin)) {
+      return true;
+    }
   }
 #endif
 


### PR DESCRIPTION
To address CSA's question regarding the permission to use SurfaceEmbed, this PR adds `IsSurfaceEmbedAllowedInFrame()` to control the creation of the SurfaceEmbedWebPlugin in a RenderFrame. Currently only frames with URL `chrome://webui-browser` are allowed to creation the plugin.

This does not affect content shell.