### PR TITLE
Compile Fix: Remove `secure_embed_embedder` from ui/webui/examples `WebContents` creation

### DIFF
--- a/ui/webui/examples/browser/ui/web/browser.cc
+++ b/ui/webui/examples/browser/ui/web/browser.cc
@@ -48,7 +48,6 @@ Browser::Browser(content::WebUI* web_ui)
   html_source->SetDefaultResource(IDR_WEBUI_EXAMPLES_BROWSER_INDEX_HTML);
 
   content::WebContents::CreateParams params(browser_context);
-  params.secure_embed_embedder = web_ui->GetWebContents();
   guest_contents_ = content::WebContents::Create(params);
 
   guest_contents::GuestContentsHandle::CreateForWebContents(

--- a/ui/webui/examples/resources/browser/index.ts
+++ b/ui/webui/examples/resources/browser/index.ts
@@ -59,8 +59,7 @@ class WebviewElement extends HTMLElement {
       this.appendChild(this.iframeElement);
       this.attached = true;
       const iframeContentWindow = this.iframeElement.contentWindow;
-      webshell.attachIframeGuest(this.guestContentsId,
-                                iframeContentWindow);
+      webshell.attachIframeGuest(this.guestContentsId, iframeContentWindow);
     }
   }
 
@@ -86,13 +85,15 @@ class SecureEmbedElement extends HTMLElement {
     super();
     this.embedElement = document.createElement('embed');
     this.embedElement.style.border = '0px';
-    this.embedElement.style.margin = "0";
-    this.embedElement.style.padding = "0";
+    this.embedElement.style.margin = '0';
+    this.embedElement.style.padding = '0';
     this.embedElement.style.flex = '1';
     this.guestContentsId = loadTimeData.getInteger('guest-contents-id');
     console.log('secure-embed guest-contents-id', this.guestContentsId);
-    this.embedElement.setAttribute('data-content-id', this.guestContentsId.toString());
-    this.embedElement.setAttribute('type', 'application/x-google-chrome-secure-embed');
+    this.embedElement.setAttribute(
+        'data-content-id', this.guestContentsId.toString());
+    this.embedElement.setAttribute(
+        'type', 'application/x-google-chrome-secure-embed');
   }
 
   connectedCallback() {
@@ -117,10 +118,10 @@ class SecureEmbedElement extends HTMLElement {
 
 webshell.allowWebviewElementRegistration(() => {
   customElements.define("webview", WebviewElement);
-  customElements.define("secureembed", SecureEmbedElement);
+  customElements.define('secureembed', SecureEmbedElement);
 });
 
-let currentEmbedElement: WebviewElement | SecureEmbedElement | null = null;
+let currentEmbedElement: WebviewElement|SecureEmbedElement|null = null;
 
 function attachViaGuestContents() {
   if (currentEmbedElement) {
@@ -128,8 +129,8 @@ function attachViaGuestContents() {
   }
 
   // Create and attach WebviewElement
-  const webview = document.createElement("webview") as WebviewElement;
-  webview.id = "webview";
+  const webview = document.createElement('webview') as WebviewElement;
+  webview.id = 'webview';
   document.body.appendChild(webview);
   currentEmbedElement = webview;
 }
@@ -140,20 +141,21 @@ function attachViaSecureEmbed() {
   }
 
   // Create and attach SecureEmbedElement
-  const secureEmbed = document.createElement("secureembed") as SecureEmbedElement;
-  secureEmbed.id = "webview";
+  const secureEmbed =
+      document.createElement('secureembed') as SecureEmbedElement;
+  secureEmbed.id = 'webview';
   document.body.appendChild(secureEmbed);
   currentEmbedElement = secureEmbed;
 }
 
-const attachGuestButton = document.getElementById("attach-guest");
+const attachGuestButton = document.getElementById('attach-guest');
 if (attachGuestButton) {
-  attachGuestButton.addEventListener("click", attachViaGuestContents);
+  attachGuestButton.addEventListener('click', attachViaGuestContents);
 }
 
-const attachSecureEmbedButton = document.getElementById("attach-secure-embed");
+const attachSecureEmbedButton = document.getElementById('attach-secure-embed');
 if (attachSecureEmbedButton) {
-  attachSecureEmbedButton.addEventListener("click", attachViaSecureEmbed);
+  attachSecureEmbedButton.addEventListener('click', attachViaSecureEmbed);
 }
 
 function navigateToAddressBarUrl() {
@@ -189,7 +191,7 @@ if (addressBar) {
 
 const backButton = document.getElementById("back");
 if (backButton) {
-  backButton.addEventListener("click", ()=>{
+  backButton.addEventListener('click', () => {
     if (currentEmbedElement) {
       currentEmbedElement.goBack();
     }
@@ -198,7 +200,7 @@ if (backButton) {
 
 const forwardButton = document.getElementById("forward");
 if (forwardButton) {
-  forwardButton.addEventListener("click", ()=>{
+  forwardButton.addEventListener('click', () => {
     if (currentEmbedElement) {
       currentEmbedElement.goForward();
     }


### PR DESCRIPTION
We remove the `secure_embed_embedder` from the `WebContents::CreateParams` in ui/webui/examples, as this member was removed in #62. This fixes a compile error.

We also run `git cl format --js`, which reformats ui/webui/examples/resources/browser/index.ts.