### PR TITLE
Switch guest contents IDs to UnguessableToken

### DIFF
--- a/chrome/browser/resources/webui_browser/app.ts
+++ b/chrome/browser/resources/webui_browser/app.ts
@@ -306,7 +306,7 @@ export class WebuiBrowserAppElement extends CrLitElement implements
   }
 
 
-  protected showSidePanel_(guestContentsId: number, title: string) {
+  protected showSidePanel_(guestContentsId: string, title: string) {
     this.showingSidePanel_ = true;
     this.$.sidePanel.show(guestContentsId, title);
   }

--- a/chrome/browser/resources/webui_browser/chrome_browser.d.ts
+++ b/chrome/browser/resources/webui_browser/chrome_browser.d.ts
@@ -8,6 +8,6 @@ declare namespace chrome {
   export namespace browser {
     // Attaches a guest contents to an iframe on the page.
     export function attachIframeGuest(
-        guestContentsId: number, contentWindow: Window): void;
+        guestContentsId: string, contentWindow: Window): void;
   }
 }

--- a/chrome/browser/resources/webui_browser/side_panel.ts
+++ b/chrome/browser/resources/webui_browser/side_panel.ts
@@ -34,7 +34,7 @@ export class SidePanel extends CrLitElement {
   protected accessor title_: string = '';
   protected accessor showing_: boolean = false;
 
-  show(guestContentsId: number, title: string) {
+  show(guestContentsId: string, title: string) {
     this.webView = new WebviewElement();
     this.webView.guestId = guestContentsId;
     this.title_ = title;

--- a/chrome/browser/resources/webui_browser/webview.ts
+++ b/chrome/browser/resources/webui_browser/webview.ts
@@ -34,11 +34,11 @@ export class WebviewElement extends CrLitElement {
 
   static override get properties() {
     return {
-      guestId: {type: Number},
+      guestId: {type: String},
     };
   }
 
-  accessor guestId: number = -1;
+  accessor guestId: string = '';
   private attached: boolean = false;
   private active: boolean = false;
   guestHandler?: GuestHandlerRemote;
@@ -49,7 +49,7 @@ export class WebviewElement extends CrLitElement {
   }
 
   protected tryToAttach() {
-    if (this.attached || this.guestId === -1) {
+    if (this.attached || this.guestId.length === 0) {
       return;
     }
 

--- a/chrome/browser/ui/webui_browser/browser.mojom
+++ b/chrome/browser/ui/webui_browser/browser.mojom
@@ -30,7 +30,8 @@ interface Page {
 
   // Shows the side panel UI. The side panel contents is hosted by a guest
   // contents.
-  ShowSidePanel(mojo_base.mojom.UnguessableToken guest_contents_id, string title);
+  ShowSidePanel(mojo_base.mojom.UnguessableToken guest_contents_id,
+                string title);
 
   // Closes the side panel, destroys the webview.
   CloseSidePanel();

--- a/chrome/browser/ui/webui_browser/browser.mojom
+++ b/chrome/browser/ui/webui_browser/browser.mojom
@@ -5,6 +5,7 @@
 module webui_browser.mojom;
 
 import "chrome/browser/ui/tabs/tab_strip_api/tab_strip_api_types.mojom";
+import "mojo/public/mojom/base/unguessable_token.mojom";
 import "mojo/public/mojom/base/values.mojom";
 import "url/mojom/url.mojom";
 
@@ -29,7 +30,7 @@ interface Page {
 
   // Shows the side panel UI. The side panel contents is hosted by a guest
   // contents.
-  ShowSidePanel(int32 guest_contents_id, string title);
+  ShowSidePanel(mojo_base.mojom.UnguessableToken guest_contents_id, string title);
 
   // Closes the side panel, destroys the webview.
   CloseSidePanel();
@@ -40,10 +41,11 @@ interface PageHandler {
   // Get the guest id for a tab id and connect up the GuestHandler.
   GetGuestIdForTabId(
       tabs_api.mojom.NodeId tab_id,
-      pending_receiver<GuestHandler> handler) => (int32 guest_id);
+      pending_receiver<GuestHandler> handler)
+      => (mojo_base.mojom.UnguessableToken guest_id);
 
   // Load TabSearch in a guest contents and returns the guest id.
-  LoadTabSearch() => (int32 guest_id);
+  LoadTabSearch() => (mojo_base.mojom.UnguessableToken guest_id);
 
   // Shows the Tab Search bubble.
   ShowTabSearchBubble(string anchor_name);

--- a/chrome/renderer/webui_browser/webui_browser_renderer_extension.cc
+++ b/chrome/renderer/webui_browser/webui_browser_renderer_extension.cc
@@ -5,6 +5,7 @@
 #include "chrome/renderer/webui_browser/webui_browser_renderer_extension.h"
 
 #include "base/check.h"
+#include "base/unguessable_token.h"
 #include "chrome/common/url_constants.h"
 #include "components/guest_contents/renderer/swap_render_frame.h"
 #include "content/public/common/isolated_world_ids.h"
@@ -57,7 +58,7 @@ content::RenderFrame* GetRenderFrame(v8::Local<v8::Value> value) {
 
 // Implementation of
 // chrome.browser.attachIframeGuest(guestInstanceId, contentWindow)
-void AttachIframeGuest(int guest_contents_id,
+void AttachIframeGuest(std::string guest_contents_id,
                        v8::Local<v8::Object> content_window) {
   content::RenderFrame* iframe_render_frame = GetRenderFrame(content_window);
   CHECK(iframe_render_frame);
@@ -66,8 +67,10 @@ void AttachIframeGuest(int guest_contents_id,
   CHECK(parent_frame);
   CHECK(parent_frame->IsWebLocalFrame());
 
-  guest_contents::renderer::SwapRenderFrame(iframe_render_frame,
-                                            guest_contents_id);
+  guest_contents::renderer::SwapRenderFrame(
+      iframe_render_frame,
+      base::UnguessableToken::DeserializeFromString(guest_contents_id)
+          .value_or(base::UnguessableToken()));
 }
 
 }  // namespace

--- a/components/guest_contents/README.md
+++ b/components/guest_contents/README.md
@@ -108,7 +108,8 @@ In your WebUI's browser-side C++ code:
           guest_contents_.get());
       auto* guest_handle = guest_contents::GuestContentsHandle::FromWebContents(
           guest_contents_.get());
-      html_source->AddInteger("guest-contents-id", guest_handle->id());
+      html_source->AddString("guest-contents-id",
+                             guest_handle->id().ToString());
     }
     ```
 
@@ -132,18 +133,23 @@ need some C++ code in the renderer.
     }
     ```
 
--   **Implement the Binding**: The AttachIframeGuest function parses the
-    arguments from JavaScript, gets the `content::RenderFrame*` for the
-    `<iframe>`, and calls the `guest_contents` helper function.
+-   **Implement the Binding**: The AttachIframeGuest function gets the
+    `content::RenderFrame*` for the `<iframe>`, and calls the `guest_contents`
+    helper function.
 
     ```c++
     // ui/webui/examples/renderer/render_frame_observer.cc
-    void AttachIframeGuest(const v8::FunctionCallbackInfo<v8::Value>& args) {
-      // ... argument parsing ...
-      int guest_contents_id = args[0].As<v8::Int32>()->Value();
+    void AttachIframeGuest(const std::string& guest_contents_id,
+                           v8::Local<v8::Object> content_window) {
+
       content::RenderFrame* render_frame = GetRenderFrame(args[1]);
       // ...
-      guest_contents::renderer::SwapRenderFrame(render_frame, guest_contents_id);
+      auto parsed_guest_contents_id =
+          base::UnguessableToken::DeserializeFromString(guest_contents_id);
+      if (parsed_guest_contents_id.has_value()) {
+          guest_contents::renderer::SwapRenderFrame(
+                  render_frame, parsed_guest_contents_id);
+      }
     }
     ```
 
@@ -171,14 +177,14 @@ Then, call a C++ binding to trigger the attachment. The example uses a
 // ui/webui/examples/resources/browser/index.ts
 class WebviewElement extends HTMLElement {
   public iframeElement: HTMLIFrameElement;
-  private guestContentsId: number;
+  private guestContentsId: string;
 
   constructor() {
     super();
     this.iframeElement = document.createElement('iframe');
     this.appendChild(this.iframeElement);
 
-    this.guestContentsId = loadTimeData.getInteger('guest-contents-id');
+    this.guestContentsId = loadTimeData.getString('guest-contents-id');
     const iframeContentWindow = this.iframeElement.contentWindow;
 
     // This is the key call that triggers the C++ logic.

--- a/components/guest_contents/browser/guest_contents_handle.cc
+++ b/components/guest_contents/browser/guest_contents_handle.cc
@@ -41,7 +41,7 @@ GuestContentsHandle* GuestContentsHandle::FromID(GuestId id) {
 GuestContentsHandle::GuestContentsHandle(content::WebContents* web_contents)
     : content::WebContentsUserData<GuestContentsHandle>(*web_contents),
       content::WebContentsObserver(web_contents),
-      id_(GetNextId()) {
+      id_(base::UnguessableToken::Create()) {
   CHECK(!GetGuestContentsMap().contains(id_));
   GetGuestContentsMap()[id_] = this;
 }
@@ -79,12 +79,6 @@ void GuestContentsHandle::DetachFromOuterWebContents() {
 
 void GuestContentsHandle::WebContentsDestroyed() {
   DetachFromOuterWebContents();
-}
-
-GuestId GuestContentsHandle::GetNextId() {
-  // GuestId of 0 is reserved to mean "no guest/content".
-  static GuestId next_id = 1;
-  return next_id++;
 }
 
 WEB_CONTENTS_USER_DATA_KEY_IMPL(GuestContentsHandle);

--- a/components/guest_contents/browser/guest_contents_handle.h
+++ b/components/guest_contents/browser/guest_contents_handle.h
@@ -7,13 +7,14 @@
 
 #include "base/component_export.h"
 #include "base/sequence_checker.h"
+#include "base/unguessable_token.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"
 
 namespace guest_contents {
 
-using GuestId = int;
+using GuestId = base::UnguessableToken;
 
 // A handle for a guest WebContents, uniquely identified by a GuestId. It
 // provides APIs for attaching and detaching the guest WebContents from the
@@ -48,9 +49,7 @@ class COMPONENT_EXPORT(GUEST_CONTENTS) GuestContentsHandle
   // content::WebContentsObserver:
   void WebContentsDestroyed() override;
 
-  GuestId GetNextId();
-
-  GuestId id_;
+  base::UnguessableToken id_;
 
   SEQUENCE_CHECKER(sequence_checker_);
 };

--- a/components/guest_contents/browser/guest_contents_handle_unittest.cc
+++ b/components/guest_contents/browser/guest_contents_handle_unittest.cc
@@ -66,8 +66,9 @@ TEST_F(GuestContentsHandleTest, CreateAndGetById) {
   EXPECT_EQ(handle, GuestContentsHandle::FromID(id));
 
   // Test invalid ID
-  EXPECT_EQ(nullptr, GuestContentsHandle::FromID(id + 1));
-  EXPECT_EQ(nullptr, GuestContentsHandle::FromID(-1));
+  EXPECT_EQ(nullptr,
+            GuestContentsHandle::FromID(base::UnguessableToken::Create()));
+  EXPECT_EQ(nullptr, GuestContentsHandle::FromID(base::UnguessableToken()));
 
   // Destroy the WebContents, which should destroy the handle
   guest_web_contents().reset();

--- a/components/guest_contents/browser/guest_contents_host_impl.cc
+++ b/components/guest_contents/browser/guest_contents_host_impl.cc
@@ -39,7 +39,7 @@ void GuestContentsHostImpl::WebContentsDestroyed() {
 
 void GuestContentsHostImpl::Attach(
     const blink::LocalFrameToken& token_of_frame_to_swap,
-    GuestId guest_contents_id,
+    const base::UnguessableToken& guest_contents_id,
     AttachCallback callback) {
   GuestContentsHandle* guest_handle =
       GuestContentsHandle::FromID(guest_contents_id);

--- a/components/guest_contents/browser/guest_contents_host_impl.h
+++ b/components/guest_contents/browser/guest_contents_host_impl.h
@@ -39,7 +39,7 @@ class COMPONENT_EXPORT(GUEST_CONTENTS) GuestContentsHostImpl
 
   // mojom::GuestContentsHost:
   void Attach(const blink::LocalFrameToken& token_of_frame_to_swap,
-              GuestId guest_contents_id,
+              const base::UnguessableToken& guest_contents_id,
               AttachCallback callback) override;
 
   raw_ptr<content::WebContents> outer_web_contents_;

--- a/components/guest_contents/common/guest_contents.mojom
+++ b/components/guest_contents/common/guest_contents.mojom
@@ -6,6 +6,7 @@ module guest_contents.mojom;
 
 import "mojo/public/mojom/base/values.mojom";
 import "third_party/blink/public/mojom/tokens/tokens.mojom";
+import "mojo/public/mojom/base/unguessable_token.mojom";
 
 // The renderer uses this interface to attach an inner WebContents to an outer
 // WebContents. Available on a WebUIController.
@@ -13,6 +14,7 @@ interface GuestContentsHost {
   // Attach an inner WebContents, identified by `guest_contents_id`, to the
   // RenderFrameHost identified by `frame_to_swap`. The guest contents id is
   // generated at the browser side on the creation of a GuestContentsHandle.
-  Attach(blink.mojom.LocalFrameToken frame_to_swap, int32 guest_contents_id)
+  Attach(blink.mojom.LocalFrameToken frame_to_swap,
+         mojo_base.mojom.UnguessableToken guest_contents_id)
       => (bool success);
 };

--- a/components/guest_contents/renderer/swap_render_frame.cc
+++ b/components/guest_contents/renderer/swap_render_frame.cc
@@ -54,7 +54,7 @@ class GuestContentsService : public base::SupportsUserData::Data {
 }  // namespace
 
 void SwapRenderFrame(content::RenderFrame* render_frame,
-                     int guest_contents_id) {
+                     const base::UnguessableToken& guest_contents_id) {
   // `render_frame` is the outer delegate frame. It must be in the same process
   // as the main frame. If not this CHECK will fail.
   CHECK(render_frame->GetMainRenderFrame());

--- a/components/guest_contents/renderer/swap_render_frame.h
+++ b/components/guest_contents/renderer/swap_render_frame.h
@@ -7,6 +7,10 @@
 
 #include "base/values.h"
 
+namespace base {
+class UnguessableToken;
+}  // namespace base
+
 namespace content {
 class RenderFrame;
 }  // namespace content
@@ -15,7 +19,8 @@ namespace guest_contents::renderer {
 
 // Asks the browser to swap `render_frame` with the main frame of the guest
 // WebContents identified by `guest_contents_id`.
-void SwapRenderFrame(content::RenderFrame* render_frame, int guest_contents_id);
+void SwapRenderFrame(content::RenderFrame* render_frame,
+                     const base::UnguessableToken& guest_contents_id);
 
 }  // namespace guest_contents::renderer
 

--- a/components/surface_embed/browser/surface_embed_browsertest.cc
+++ b/components/surface_embed/browser/surface_embed_browsertest.cc
@@ -603,8 +603,8 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest, Detach) {
 
   VerifyBoxRendering(SK_ColorRED);
 
-  // Change the data-content-id attribute to 0 to trigger a detach.
-  std::string script_cause_detach = "setDataContentId(0);";
+  // Change the data-content-id attribute to '' to trigger a detach.
+  std::string script_cause_detach = "setDataContentId('');";
   ASSERT_TRUE(content::ExecJs(web_contents(), script_cause_detach));
   EXPECT_EQ(guest_contents->GetSurfaceEmbedConnector(), nullptr);
   VerifyBoxRendering(SK_ColorWHITE);
@@ -679,8 +679,8 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest,
   AttachGuestToEmbed(guest_contents.get());
   VerifyBoxRendering(SK_ColorRED);
 
-  // Change the data-content-id attribute to 0 to trigger a detach.
-  std::string script_cause_detach = "setDataContentId(0);";
+  // Change the data-content-id attribute to '' to trigger a detach.
+  std::string script_cause_detach = "setDataContentId('');";
   ASSERT_TRUE(content::ExecJs(web_contents(), script_cause_detach));
   EXPECT_EQ(guest_contents->GetSurfaceEmbedConnector(), nullptr);
   VerifyBoxRendering(SK_ColorWHITE);
@@ -691,40 +691,6 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest,
       "setDataContentId(" + FormatGuestId(guest_id) + ");";
   ASSERT_TRUE(content::ExecJs(web_contents(), script_reattach));
   VerifyBoxRendering(SK_ColorRED);
-}
-
-IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest, InvalidContentIdNegative) {
-  // Test that specifying an invalid (negative) content_id creates a host but
-  // doesn't attach any guest, resulting in white rendering.
-  NavigateToAttachHarness();
-
-  std::string script = "createEmbed(-1);";
-  ASSERT_TRUE(content::ExecJs(web_contents(), script));
-
-  // Host should be created even with invalid content_id but no attach should
-  // happen.
-  ASSERT_TRUE(WaitForHostCreation());
-  EXPECT_EQ(1u, SurfaceEmbedHost::GetInstanceCountForTesting());
-  EXPECT_EQ(0u, SurfaceEmbedHost::GetAttachedInstanceCountForTesting());
-  VerifyBoxRendering(SK_ColorWHITE);
-}
-
-IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest,
-                       AttachValidGuestThenUpdateToNegativeContentId) {
-  // Test that attaching a valid guest shows its content, but updating to a
-  // negative content_id detaches and results in white rendering.
-  auto guest_contents = SetupHarnessAndGuestWithContent(kRedBoxUrl);
-  AttachGuestToEmbed(guest_contents.get());
-
-  VerifyBoxRendering(SK_ColorRED);
-  EXPECT_NE(guest_contents->GetSurfaceEmbedConnector(), nullptr);
-
-  // Update the data-content-id to a negative number to trigger detachment.
-  std::string script_detach = "setDataContentId(-5);";
-  ASSERT_TRUE(content::ExecJs(web_contents(), script_detach));
-
-  VerifyBoxRendering(SK_ColorWHITE);
-  EXPECT_EQ(guest_contents->GetSurfaceEmbedConnector(), nullptr);
 }
 
 // Tests that calling focus() on an <embed> makes the guest WebContents focused.

--- a/components/surface_embed/browser/surface_embed_browsertest.cc
+++ b/components/surface_embed/browser/surface_embed_browsertest.cc
@@ -42,28 +42,29 @@ class SurfaceEmbedBrowserTest : public content::ContentBrowserTest {
   class ScopedDataContentIdMonitor {
    public:
     ScopedDataContentIdMonitor(content::WebContents* web_contents,
-                               bool expect_zero_change)
-        : web_contents_(web_contents), expect_zero_change_(expect_zero_change) {
+                               bool expect_empty_change)
+        : web_contents_(web_contents),
+          expect_empty_change_(expect_empty_change) {
       EXPECT_TRUE(
           content::ExecJs(web_contents_, "startMonitoringDataContentId();"));
     }
 
     ~ScopedDataContentIdMonitor() {
-      bool zero_detected =
-          content::EvalJs(web_contents_, "wasZeroChangeDetected()")
+      bool empty_detected =
+          content::EvalJs(web_contents_, "wasEmptyChangeDetected()")
               .ExtractBool();
 
-      if (expect_zero_change_) {
-        // Wait for zero change if we expect it but haven't seen it yet.
-        if (!zero_detected) {
+      if (expect_empty_change_) {
+        // Wait for empty change if we expect it but haven't seen it yet.
+        if (!empty_detected) {
           EXPECT_TRUE(base::test::RunUntil([&]() {
-            return content::EvalJs(web_contents_, "wasZeroChangeDetected()")
+            return content::EvalJs(web_contents_, "wasEmptyChangeDetected()")
                 .ExtractBool();
-          })) << "data-content-id was not set to 0 as expected";
+          })) << "data-content-id was not set to '' as expected";
         }
       } else {
-        EXPECT_FALSE(zero_detected)
-            << "data-content-id was unexpectedly set to 0 (DetachedByHost "
+        EXPECT_FALSE(empty_detected)
+            << "data-content-id was unexpectedly set to '' (DetachedByHost "
                "incorrectly triggered)";
       }
 
@@ -77,7 +78,7 @@ class SurfaceEmbedBrowserTest : public content::ContentBrowserTest {
 
    private:
     raw_ptr<content::WebContents> web_contents_;
-    bool expect_zero_change_;
+    bool expect_empty_change_;
   };
 
   void SetUpCommandLine(base::CommandLine* command_line) override {
@@ -222,24 +223,28 @@ class SurfaceEmbedBrowserTest : public content::ContentBrowserTest {
         guest_contents::GuestContentsHandle::CreateForWebContents(
             guest_contents);
     ASSERT_NE(guest_handle, nullptr);
-    std::string script =
-        "createEmbed(" + base::NumberToString(guest_handle->id());
+    std::string script = "createEmbed('" + guest_handle->id().ToString();
     if (embed_id.has_value()) {
-      script += ", '" + embed_id.value() + "'";
+      script += "', '" + embed_id.value();
     }
-    script += ");";
+    script += "');";
     ASSERT_TRUE(content::ExecJs(web_contents(), script));
     ASSERT_TRUE(WaitForHostAttachment(1));
     EXPECT_NE(guest_contents->GetSurfaceEmbedConnector(), nullptr);
   }
 
   // Get the guest handle for the provided guest WebContents.
-  int GetGuestHandleId(content::WebContents* guest_contents) {
+  base::UnguessableToken GetGuestHandleId(
+      content::WebContents* guest_contents) {
     guest_contents::GuestContentsHandle* guest_handle =
         guest_contents::GuestContentsHandle::CreateForWebContents(
             guest_contents);
     EXPECT_NE(guest_handle, nullptr);
-    return guest_handle ? guest_handle->id() : -1;
+    return guest_handle ? guest_handle->id() : base::UnguessableToken();
+  }
+
+  std::string FormatGuestId(const base::UnguessableToken& guest_id) {
+    return base::StrCat({"'", guest_id.ToString(), "'"});
   }
 
   // Setup guest with harness navigation and content loading.
@@ -332,29 +337,29 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest,
   // Create and load both guests.
   auto guest_contents_red = CreateGuestWebContents();
   NavigateGuestToUrl(guest_contents_red.get(), kRedBoxUrl);
-  int guest_id_red = GetGuestHandleId(guest_contents_red.get());
+  auto guest_id_red = GetGuestHandleId(guest_contents_red.get());
 
   auto guest_contents_blue = CreateGuestWebContents();
   NavigateGuestToUrl(guest_contents_blue.get(), kBlueBoxUrl);
-  int guest_id_blue = GetGuestHandleId(guest_contents_blue.get());
+  auto guest_id_blue = GetGuestHandleId(guest_contents_blue.get());
 
   // Attach the red guest first.
   AttachGuestToEmbed(guest_contents_red.get());
   VerifyBoxRendering(SK_ColorRED);
 
   ScopedDataContentIdMonitor monitor(web_contents(),
-                                     /*expect_zero_change=*/false);
+                                     /*expect_empty_change=*/false);
 
   // Swap to the blue guest by changing the data-content-id attribute.
   std::string script_blue =
-      "setDataContentId(" + base::NumberToString(guest_id_blue) + ");";
+      "setDataContentId(" + FormatGuestId(guest_id_blue) + ");";
   ASSERT_TRUE(content::ExecJs(web_contents(), script_blue));
   VerifyBoxRendering(SK_ColorBLUE);
   EXPECT_EQ(guest_contents_red->GetSurfaceEmbedConnector(), nullptr);
 
   // Swap back to red guest.
   std::string script_red_again =
-      "setDataContentId(" + base::NumberToString(guest_id_red) + ");";
+      "setDataContentId(" + FormatGuestId(guest_id_red) + ");";
   ASSERT_TRUE(content::ExecJs(web_contents(), script_red_again));
   VerifyBoxRendering(SK_ColorRED);
   EXPECT_EQ(guest_contents_blue->GetSurfaceEmbedConnector(), nullptr);
@@ -408,7 +413,7 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest, VisibilityHiddenSwapGuest) {
 
   auto guest_contents_blue = CreateGuestWebContents();
   NavigateGuestToUrl(guest_contents_blue.get(), kBlueBoxUrl);
-  int guest_id_blue = GetGuestHandleId(guest_contents_blue.get());
+  auto guest_id_blue = GetGuestHandleId(guest_contents_blue.get());
 
   // Attach the red guest first.
   AttachGuestToEmbed(guest_contents_red.get());
@@ -421,11 +426,11 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest, VisibilityHiddenSwapGuest) {
   VerifyBoxRendering(SK_ColorWHITE);
 
   ScopedDataContentIdMonitor monitor(web_contents(),
-                                     /*expect_zero_change=*/false);
+                                     /*expect_empty_change=*/false);
 
   // Swap to the blue guest while hidden.
   std::string script_blue =
-      "setDataContentId(" + base::NumberToString(guest_id_blue) + ");";
+      "setDataContentId(" + FormatGuestId(guest_id_blue) + ");";
   ASSERT_TRUE(content::ExecJs(web_contents(), script_blue));
   VerifyBoxRendering(SK_ColorWHITE);
 
@@ -445,7 +450,7 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest, DisplayNoneSwapGuest) {
 
   auto guest_contents_blue = CreateGuestWebContents();
   NavigateGuestToUrl(guest_contents_blue.get(), kBlueBoxUrl);
-  int guest_id_blue = GetGuestHandleId(guest_contents_blue.get());
+  auto guest_id_blue = GetGuestHandleId(guest_contents_blue.get());
 
   // Attach the red guest first.
   AttachGuestToEmbed(guest_contents_red.get());
@@ -458,11 +463,11 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest, DisplayNoneSwapGuest) {
   VerifyBoxRendering(SK_ColorWHITE);
 
   ScopedDataContentIdMonitor monitor(web_contents(),
-                                     /*expect_zero_change=*/false);
+                                     /*expect_empty_change=*/false);
 
   // Swap to the blue guest while display is none.
   std::string script_blue =
-      "setDataContentId(" + base::NumberToString(guest_id_blue) + ");";
+      "setDataContentId(" + FormatGuestId(guest_id_blue) + ");";
   ASSERT_TRUE(content::ExecJs(web_contents(), script_blue));
   VerifyBoxRendering(SK_ColorWHITE);
 
@@ -481,7 +486,7 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest, TwoEmbedSameContentId) {
   // Create and load both guests.
   auto guest_contents_red = CreateGuestWebContents();
   NavigateGuestToUrl(guest_contents_red.get(), kRedBoxUrl);
-  int guest_id_red = GetGuestHandleId(guest_contents_red.get());
+  auto guest_id_red = GetGuestHandleId(guest_contents_red.get());
 
   // Attach the red guest first.
   AttachGuestToEmbedWithId(guest_contents_red.get(), "embed1");
@@ -497,7 +502,7 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest, TwoEmbedSameContentId) {
   // The first embed's data-content-id should be reset to 0 since it was
   // forcibly detached when the guest was attached to the 2nd embed.
   ScopedDataContentIdMonitor monitor(web_contents(),
-                                     /*expect_zero_change=*/true);
+                                     /*expect_empty_change=*/true);
 
   // Add a 2nd <embed> with ID 'embed2' that uses the same content id.
   AttachGuestToEmbedWithId(guest_contents_red.get(), "embed2");
@@ -516,17 +521,17 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest, TwoEmbedSameContentId) {
   // the original guest ID to ensure that a forced detachment doesn't prevent
   // subsequent re-attachment.
   std::string script_reattach_first =
-      "setDataContentId(" + base::NumberToString(guest_id_red) + ", 'embed1');";
+      "setDataContentId(" + FormatGuestId(guest_id_red) + ", 'embed1');";
   ASSERT_TRUE(content::ExecJs(web_contents(), script_reattach_first));
   VerifyBoxRendering(SK_ColorRED);
   EXPECT_TRUE(first_host_delegate->IsAttachedForTesting());
   EXPECT_TRUE(content::EvalJs(web_contents(), "getDataContentId('embed2')")
-                  .ExtractString() == "0");
+                  .ExtractString() == "");
 }
 
 IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest, ReattachSameGuestToNewEmbed) {
   auto guest_contents = SetupHarnessAndGuestWithContent(kRedBoxUrl);
-  int guest_id = GetGuestHandleId(guest_contents.get());
+  auto guest_id = GetGuestHandleId(guest_contents.get());
 
   AttachGuestToEmbed(guest_contents.get());
   VerifyBoxRendering(SK_ColorRED);
@@ -537,7 +542,7 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest, ReattachSameGuestToNewEmbed) {
   VerifyBoxRendering(SK_ColorWHITE);
 
   // Create a new embed element and attach the same guest.
-  std::string script = "createEmbed(" + base::NumberToString(guest_id) + ");";
+  std::string script = "createEmbed(" + FormatGuestId(guest_id) + ");";
   ASSERT_TRUE(content::ExecJs(web_contents(), script));
   VerifyBoxRendering(SK_ColorRED);
 }
@@ -605,9 +610,9 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest, Detach) {
   VerifyBoxRendering(SK_ColorWHITE);
 
   // Re-attach the same guest.
-  int guest_id = GetGuestHandleId(guest_contents.get());
+  auto guest_id = GetGuestHandleId(guest_contents.get());
   std::string script_reattach =
-      "setDataContentId(" + base::NumberToString(guest_id) + ");";
+      "setDataContentId(" + FormatGuestId(guest_id) + ");";
   ASSERT_TRUE(content::ExecJs(web_contents(), script_reattach));
   VerifyBoxRendering(SK_ColorRED);
   EXPECT_NE(guest_contents->GetSurfaceEmbedConnector(), nullptr);
@@ -681,9 +686,9 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedBrowserTest,
   VerifyBoxRendering(SK_ColorWHITE);
 
   // Reattach the same guest.
-  int guest_id = GetGuestHandleId(guest_contents.get());
+  auto guest_id = GetGuestHandleId(guest_contents.get());
   std::string script_reattach =
-      "setDataContentId(" + base::NumberToString(guest_id) + ");;";
+      "setDataContentId(" + FormatGuestId(guest_id) + ");";
   ASSERT_TRUE(content::ExecJs(web_contents(), script_reattach));
   VerifyBoxRendering(SK_ColorRED);
 }

--- a/components/surface_embed/browser/surface_embed_host.cc
+++ b/components/surface_embed/browser/surface_embed_host.cc
@@ -50,20 +50,20 @@ void SurfaceEmbedHost::SetSurfaceEmbed(
       &SurfaceEmbedHost::OnSurfaceEmbedDisconnected, base::Unretained(this)));
 }
 
-void SurfaceEmbedHost::AttachConnector(int64_t content_id) {
+void SurfaceEmbedHost::AttachConnector(
+    const base::UnguessableToken& content_id) {
   // Should never call attach without having a valid SurfaceEmbed remote already
   // bound.
   CHECK(surface_embed_);
 
-  int guest_id = static_cast<int>(content_id);
-  if (guest_id <= 0) {
+  if (content_id.is_empty()) {
     mojo::ReportBadMessage(
         "Invalid content_id in SurfaceEmbedHost::AttachConnector");
     return;
   }
 
   guest_contents::GuestContentsHandle* guest_handle =
-      guest_contents::GuestContentsHandle::FromID(guest_id);
+      guest_contents::GuestContentsHandle::FromID(content_id);
 
   if (!guest_handle) {
     mojo::ReportBadMessage(

--- a/components/surface_embed/browser/surface_embed_host.h
+++ b/components/surface_embed/browser/surface_embed_host.h
@@ -44,7 +44,7 @@ class COMPONENT_EXPORT(SURFACE_EMBED) SurfaceEmbedHost
   // mojom::SurfaceEmbedHost implementation:
   void SetSurfaceEmbed(mojo::PendingAssociatedRemote<mojom::SurfaceEmbed>
                            surface_embed) override;
-  void AttachConnector(int64_t content_id) override;
+  void AttachConnector(const base::UnguessableToken& content_id) override;
   void DetachConnector() override;
   void SynchronizeVisualProperties(
       const blink::FrameVisualProperties& visual_properties,

--- a/components/surface_embed/browser/surface_embed_web_plugin_browsertest.cc
+++ b/components/surface_embed/browser/surface_embed_web_plugin_browsertest.cc
@@ -493,20 +493,21 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest, Detach) {
   EXPECT_EQ(1, host->attach_call_count());
   EXPECT_FALSE(host->last_content_id().is_empty());
 
-  // Change the data-content-id attribute to 0 to trigger a detach.
+  // Change the data-content-id attribute to an empty string to trigger a
+  // detach.
   ASSERT_TRUE(content::ExecJs(
       web_contents(),
-      "document.embeds[0].setAttribute('data-content-id', '0');"));
+      "document.embeds[0].setAttribute('data-content-id', '');"));
 
   ASSERT_TRUE(WaitForDetachCall(host));
   EXPECT_EQ(1, host->detach_call_count());
   EXPECT_TRUE(host->last_content_id().is_empty());
 }
 
-IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest,
-                       UpdateDataAttributeWithInvalidStrings) {
+IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest, Detach2) {
   NavigateToTestUrl(kTestUrl);
-  ASSERT_EQ(kSingleEmbedCount, CountEmbedElementsInPage());
+
+  EXPECT_EQ(kSingleEmbedCount, CountEmbedElementsInPage());
   ASSERT_EQ(kSingleEmbedCount, GetMockHostCount());
 
   MockSurfaceEmbedHost* host = GetMockHost(0);
@@ -516,38 +517,14 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest,
   EXPECT_EQ(1, host->attach_call_count());
   EXPECT_FALSE(host->last_content_id().is_empty());
 
-  // Test a variety of invalid data-content-id attribute values to ensure that
-  // they don't lead to calls to attach on the host. The first one will cause a
-  // detach.
+  // Remove the data-content-id attribute to trigger a detach.
   ASSERT_TRUE(content::ExecJs(
       web_contents(),
-      "document.embeds[0].setAttribute('data-content-id', 'invalid');"));
-  EXPECT_EQ(1, host->attach_call_count());
+      "document.embeds[0].removeAttribute('data-content-id');"));
+
+  ASSERT_TRUE(WaitForDetachCall(host));
   EXPECT_EQ(1, host->detach_call_count());
   EXPECT_TRUE(host->last_content_id().is_empty());
-
-  ASSERT_TRUE(content::ExecJs(
-      web_contents(),
-      "document.embeds[0].setAttribute('data-content-id', '123abc');"));
-  EXPECT_EQ(1, host->attach_call_count());
-  EXPECT_EQ(1, host->detach_call_count());
-  EXPECT_TRUE(host->last_content_id().is_empty());
-
-  ASSERT_TRUE(content::ExecJs(
-      web_contents(),
-      "document.embeds[0].setAttribute('data-content-id', '');"));
-  EXPECT_EQ(1, host->attach_call_count());
-  EXPECT_EQ(1, host->detach_call_count());
-  EXPECT_TRUE(host->last_content_id().is_empty());
-
-  base::UnguessableToken id2 = base::UnguessableToken::Create();
-  ASSERT_TRUE(content::ExecJs(
-      web_contents(),
-      base::StrCat({"document.embeds[0].setAttribute('data-content-id', '",
-                    id2.ToString(), "');"})));
-  ASSERT_TRUE(WaitForAttachCall(host));
-  EXPECT_EQ(2, host->attach_call_count());
-  EXPECT_EQ(id2, host->last_content_id());
 }
 
 }  // namespace surface_embed

--- a/components/surface_embed/browser/surface_embed_web_plugin_browsertest.cc
+++ b/components/surface_embed/browser/surface_embed_web_plugin_browsertest.cc
@@ -108,7 +108,7 @@ class MockSurfaceEmbedHost : public mojom::SurfaceEmbedHost {
                        base::Unretained(this)));
   }
 
-  void AttachConnector(int64_t content_id) override {
+  void AttachConnector(const base::UnguessableToken& content_id) override {
     CHECK(surface_embed_);
     attach_call_count_++;
     last_content_id_ = content_id;
@@ -116,8 +116,7 @@ class MockSurfaceEmbedHost : public mojom::SurfaceEmbedHost {
 
   void DetachConnector() override {
     detach_call_count_++;
-    // TODO(surface-embed): Create a constant for invalid content ID.
-    last_content_id_ = 0;
+    last_content_id_ = base::UnguessableToken();
   }
 
   void SynchronizeVisualProperties(
@@ -125,6 +124,10 @@ class MockSurfaceEmbedHost : public mojom::SurfaceEmbedHost {
       bool is_visible) override {}
 
   void SetFocus(bool focused, blink::mojom::FocusType focus_type) override {}
+
+  void SetParentAccessibilityInfo(
+      int32_t ax_node_id,
+      const base::UnguessableToken& ax_tree_token) override {}
 
   void OnSurfaceEmbedDisconnected() { surface_embed_.reset(); }
 
@@ -134,13 +137,13 @@ class MockSurfaceEmbedHost : public mojom::SurfaceEmbedHost {
 
   int attach_call_count() const { return attach_call_count_; }
   int detach_call_count() const { return detach_call_count_; }
-  int64_t last_content_id() const { return last_content_id_; }
+  base::UnguessableToken last_content_id() const { return last_content_id_; }
 
  private:
   raw_ptr<SurfaceEmbedHostTracker> tracker_;
   int attach_call_count_ = 0;
   int detach_call_count_ = 0;
-  int64_t last_content_id_ = -1;
+  base::UnguessableToken last_content_id_;
   base::OnceClosure disconnect_callback_;
   mojo::AssociatedRemote<mojom::SurfaceEmbed> surface_embed_;
 };
@@ -248,7 +251,7 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest, EmbedTagCreatesPlugin) {
   ASSERT_TRUE(WaitForAttachCall(host));
   EXPECT_EQ(1, host->attach_call_count());
 
-  EXPECT_EQ(1, host->last_content_id());
+  EXPECT_FALSE(host->last_content_id().is_empty());
 }
 
 IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest, MultipleEmbedTags) {
@@ -258,9 +261,9 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest, MultipleEmbedTags) {
   ASSERT_EQ(kMultipleEmbedCount, GetMockHostCount());
 
   // Verify each host has an independent Mojo connection and receives a call to
-  // AttachConnector(). Collect all content_ids to verify we see 1, 2, and 3
-  // (order is not deterministic).
-  std::set<int64_t> content_ids;
+  // AttachConnector(). Collect all content_ids to verify we see three distinct
+  // ones (order is not deterministic).
+  std::set<base::UnguessableToken> content_ids;
   for (size_t i = 0; i < kMultipleEmbedCount; i++) {
     MockSurfaceEmbedHost* host = GetMockHost(i);
     ASSERT_NE(nullptr, host);
@@ -269,7 +272,7 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest, MultipleEmbedTags) {
     content_ids.insert(host->last_content_id());
   }
 
-  EXPECT_EQ(std::set<int64_t>({1, 2, 3}), content_ids);
+  EXPECT_EQ(3u, content_ids.size());
 }
 
 IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest, PluginDestruction) {
@@ -427,27 +430,33 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest,
   MockSurfaceEmbedHost* host = GetMockHost(0);
   ASSERT_NE(nullptr, host);
   ASSERT_TRUE(WaitForAttachCall(host));
-  EXPECT_EQ(1, host->last_content_id());
+  EXPECT_FALSE(host->last_content_id().is_empty());
 
   // Set up disconnect callback to detect if host is destroyed
   bool host_disconnected = false;
   host->SetDisconnectCallback(
       base::BindLambdaForTesting([&]() { host_disconnected = true; }));
 
+  base::UnguessableToken id2 = base::UnguessableToken::Create();
+
   // Change the data-content-id attribute
   ASSERT_TRUE(content::ExecJs(
       web_contents(),
-      "document.embeds[0].setAttribute('data-content-id', '5');"));
+      base::StrCat({"document.embeds[0].setAttribute('data-content-id', '",
+                    id2.ToString(), "');"})));
 
   // Add a new embed element and wait for it to attach. This ensures that
   // the renderer and browser have fully processed the attribute change above.
-  ASSERT_TRUE(
-      content::ExecJs(web_contents(),
-                      "const newEmbed = document.createElement('embed');"
-                      "newEmbed.setAttribute('type', "
-                      "'application/x-google-chrome-surface-embed');"
-                      "newEmbed.setAttribute('data-content-id', '10');"
-                      "document.body.appendChild(newEmbed);"));
+  base::UnguessableToken id3 = base::UnguessableToken::Create();
+  ASSERT_TRUE(content::ExecJs(
+      web_contents(),
+      base::StrCat({"const newEmbed = document.createElement('embed');"
+                    "newEmbed.setAttribute('type', "
+                    "'application/x-google-chrome-surface-embed');"
+                    "newEmbed.setAttribute('data-content-id', '",
+                    id3.ToString(),
+                    "');"
+                    "document.body.appendChild(newEmbed);"})));
 
   EXPECT_EQ(kFinalEmbedCount, CountEmbedElementsInPage());
   WaitForHostAdded(kFinalEmbedCount);
@@ -457,7 +466,7 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest,
   ASSERT_NE(nullptr, second_host);
   ASSERT_TRUE(WaitForAttachCall(second_host));
   EXPECT_EQ(1, second_host->attach_call_count());
-  EXPECT_EQ(10, second_host->last_content_id());
+  EXPECT_EQ(id3, second_host->last_content_id());
 
   // Verify the original host was not disconnected or recreated
   EXPECT_FALSE(host_disconnected);
@@ -465,7 +474,10 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest,
   // But we do expect it to have received a second AttachConnector() call with
   // the new content ID.
   EXPECT_EQ(2, host->attach_call_count());
-  EXPECT_EQ(5, host->last_content_id());
+  EXPECT_EQ(id2, host->last_content_id());
+
+  // Clear callback since the current one is tied to this frame.
+  host->SetDisconnectCallback(base::OnceClosure());
 }
 
 IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest, Detach) {
@@ -479,7 +491,7 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest, Detach) {
 
   ASSERT_TRUE(WaitForAttachCall(host));
   EXPECT_EQ(1, host->attach_call_count());
-  EXPECT_EQ(1, host->last_content_id());
+  EXPECT_FALSE(host->last_content_id().is_empty());
 
   // Change the data-content-id attribute to 0 to trigger a detach.
   ASSERT_TRUE(content::ExecJs(
@@ -488,7 +500,7 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest, Detach) {
 
   ASSERT_TRUE(WaitForDetachCall(host));
   EXPECT_EQ(1, host->detach_call_count());
-  EXPECT_EQ(0, host->last_content_id());
+  EXPECT_TRUE(host->last_content_id().is_empty());
 }
 
 IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest,
@@ -502,34 +514,40 @@ IN_PROC_BROWSER_TEST_F(SurfaceEmbedRendererTest,
 
   ASSERT_TRUE(WaitForAttachCall(host));
   EXPECT_EQ(1, host->attach_call_count());
-  EXPECT_EQ(1, host->last_content_id());
+  EXPECT_FALSE(host->last_content_id().is_empty());
 
   // Test a variety of invalid data-content-id attribute values to ensure that
-  // they don't lead to calls to attach on the host.
+  // they don't lead to calls to attach on the host. The first one will cause a
+  // detach.
   ASSERT_TRUE(content::ExecJs(
       web_contents(),
       "document.embeds[0].setAttribute('data-content-id', 'invalid');"));
   EXPECT_EQ(1, host->attach_call_count());
-  EXPECT_EQ(0, host->detach_call_count());
+  EXPECT_EQ(1, host->detach_call_count());
+  EXPECT_TRUE(host->last_content_id().is_empty());
 
   ASSERT_TRUE(content::ExecJs(
       web_contents(),
       "document.embeds[0].setAttribute('data-content-id', '123abc');"));
   EXPECT_EQ(1, host->attach_call_count());
-  EXPECT_EQ(1, host->last_content_id());
+  EXPECT_EQ(1, host->detach_call_count());
+  EXPECT_TRUE(host->last_content_id().is_empty());
 
   ASSERT_TRUE(content::ExecJs(
       web_contents(),
       "document.embeds[0].setAttribute('data-content-id', '');"));
   EXPECT_EQ(1, host->attach_call_count());
-  EXPECT_EQ(0, host->detach_call_count());
+  EXPECT_EQ(1, host->detach_call_count());
+  EXPECT_TRUE(host->last_content_id().is_empty());
 
+  base::UnguessableToken id2 = base::UnguessableToken::Create();
   ASSERT_TRUE(content::ExecJs(
       web_contents(),
-      "document.embeds[0].setAttribute('data-content-id', '5');"));
+      base::StrCat({"document.embeds[0].setAttribute('data-content-id', '",
+                    id2.ToString(), "');"})));
   ASSERT_TRUE(WaitForAttachCall(host));
   EXPECT_EQ(2, host->attach_call_count());
-  EXPECT_EQ(5, host->last_content_id());
+  EXPECT_EQ(id2, host->last_content_id());
 }
 
 }  // namespace surface_embed

--- a/components/surface_embed/common/surface_embed.mojom
+++ b/components/surface_embed/common/surface_embed.mojom
@@ -46,7 +46,7 @@ interface SurfaceEmbedHost {
 
   // Attaches the guest content identified by `content_id` (a
   // GuestContentsHandle) to the host.
-  AttachConnector(int64 content_id);
+  AttachConnector(mojo_base.mojom.UnguessableToken content_id);
 
   // Detaches the guest content from the host.
   DetachConnector();

--- a/components/surface_embed/renderer/surface_embed_web_plugin.cc
+++ b/components/surface_embed/renderer/surface_embed_web_plugin.cc
@@ -36,6 +36,20 @@
 
 namespace surface_embed {
 
+namespace {
+
+base::UnguessableToken DecodeContentId(const std::string& id_string) {
+  if (id_string.empty()) {
+    return base::UnguessableToken();
+  }
+  std::optional<base::UnguessableToken> maybe_id =
+      base::UnguessableToken::DeserializeFromString(id_string);
+  CHECK(maybe_id.has_value());
+  return *maybe_id;
+}
+
+}  // namespace
+
 // Helper class to detect when accessibility mode is enabled.
 class SurfaceEmbedWebPlugin::AccessibilityObserver
     : public content::RenderFrameObserver {
@@ -76,9 +90,7 @@ SurfaceEmbedWebPlugin* SurfaceEmbedWebPlugin::Create(
   base::UnguessableToken contents_id;
   for (size_t i = 0; i < params.attribute_names.size(); ++i) {
     if (params.attribute_names[i].Utf8() == "data-content-id") {
-      contents_id = base::UnguessableToken::DeserializeFromString(
-                        params.attribute_values[i].Utf8())
-                        .value_or(base::UnguessableToken());
+      contents_id = DecodeContentId(params.attribute_values[i].Utf8());
       break;
     }
   }
@@ -368,8 +380,7 @@ void SurfaceEmbedWebPlugin::UpdateDataAttribute(
   // We treat invalid values as empty/detach here to make detach syntax not
   // rely on our implementation details.
   base::UnguessableToken new_contents_id =
-      base::UnguessableToken::DeserializeFromString(attribute_value.Utf8())
-          .value_or(base::UnguessableToken());
+      DecodeContentId(attribute_value.Utf8());
   if (new_contents_id == contents_id_) {
     return;
   }

--- a/components/surface_embed/renderer/surface_embed_web_plugin.cc
+++ b/components/surface_embed/renderer/surface_embed_web_plugin.cc
@@ -73,10 +73,12 @@ SurfaceEmbedWebPlugin* SurfaceEmbedWebPlugin::Create(
   render_frame->GetRemoteAssociatedInterfaces()->GetInterface(&host);
 
   // Read the content ID from the data-content-id attribute
-  int contents_id = -1;
+  base::UnguessableToken contents_id;
   for (size_t i = 0; i < params.attribute_names.size(); ++i) {
     if (params.attribute_names[i].Utf8() == "data-content-id") {
-      base::StringToInt(params.attribute_values[i].Utf8(), &contents_id);
+      contents_id = base::UnguessableToken::DeserializeFromString(
+                        params.attribute_values[i].Utf8())
+                        .value_or(base::UnguessableToken());
       break;
     }
   }
@@ -86,7 +88,7 @@ SurfaceEmbedWebPlugin* SurfaceEmbedWebPlugin::Create(
 
 SurfaceEmbedWebPlugin::SurfaceEmbedWebPlugin(
     mojo::AssociatedRemote<mojom::SurfaceEmbedHost> host,
-    int contents_id,
+    const base::UnguessableToken& contents_id,
     content::RenderFrame* render_frame)
     : contents_id_(contents_id),
       host_(std::move(host)),
@@ -117,7 +119,7 @@ bool SurfaceEmbedWebPlugin::Initialize(blink::WebPluginContainer* container) {
     host_->SetSurfaceEmbed(std::move(pending_remote));
 
     // Then attach with the content ID.
-    if (contents_id_ > 0) {
+    if (!contents_id_.is_empty()) {
       host_->AttachConnector(contents_id_);
     }
 
@@ -363,15 +365,18 @@ void SurfaceEmbedWebPlugin::UpdateDataAttribute(
     return;
   }
 
-  int new_contents_id = -1;
-  if (!base::StringToInt(attribute_value.Utf8(), &new_contents_id) ||
-      new_contents_id == contents_id_) {
+  // We treat invalid values as empty/detach here to make detach syntax not
+  // rely on our implementation details.
+  base::UnguessableToken new_contents_id =
+      base::UnguessableToken::DeserializeFromString(attribute_value.Utf8())
+          .value_or(base::UnguessableToken());
+  if (new_contents_id == contents_id_) {
     return;
   }
 
   contents_id_ = new_contents_id;
   if (host_) {
-    if (contents_id_ <= 0) {
+    if (contents_id_.is_empty()) {
       host_->DetachConnector();
       DetachInternal();
     } else {
@@ -453,11 +458,11 @@ void SurfaceEmbedWebPlugin::DetachPlugin() {
   // The browser forcibly detached the guest that was previously attached to
   // to this plugin. This can happen when the guest is being re-attached
   // elsewhere.
-  contents_id_ = 0;
+  contents_id_ = base::UnguessableToken();
   // We send this change back to the renderer so that the data-content-id
   // attribute is updated accordingly. It'll be async but will allow detection
   // of the detachment eventually.
-  container_->GetElement().SetAttribute("data-content-id", "0");
+  container_->GetElement().SetAttribute("data-content-id", "");
   DetachInternal();
 }
 

--- a/components/surface_embed/renderer/surface_embed_web_plugin.h
+++ b/components/surface_embed/renderer/surface_embed_web_plugin.h
@@ -7,6 +7,7 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
+#include "base/unguessable_token.h"
 #include "cc/layers/content_layer_client.h"
 #include "components/surface_embed/common/surface_embed.mojom.h"
 #include "mojo/public/cpp/bindings/associated_receiver.h"
@@ -82,7 +83,7 @@ class SurfaceEmbedWebPlugin : public blink::WebPlugin,
 
   explicit SurfaceEmbedWebPlugin(
       mojo::AssociatedRemote<mojom::SurfaceEmbedHost> host,
-      int contents_id,
+      const base::UnguessableToken& contents_id,
       content::RenderFrame* render_frame);
 
   void OnSurfaceEmbedHostDisconnected();
@@ -97,7 +98,7 @@ class SurfaceEmbedWebPlugin : public blink::WebPlugin,
   void InitializeSurfaceLayer();
 
   // The guest contents ID parsed from the `data-content-id` attribute.
-  int contents_id_ = -1;
+  base::UnguessableToken contents_id_;
 
   raw_ptr<blink::WebPluginContainer> container_ = nullptr;
   scoped_refptr<cc::SurfaceLayer> layer_;

--- a/components/test/data/surface_embed/embed_tag.html
+++ b/components/test/data/surface_embed/embed_tag.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-<embed data-content-id="1" type="application/x-google-chrome-surface-embed" />
+<embed data-content-id="1234567890ABCDEFFEDCBA0987654321" type="application/x-google-chrome-surface-embed" />
 </body>
 </html>

--- a/components/test/data/surface_embed/multiple_embeds.html
+++ b/components/test/data/surface_embed/multiple_embeds.html
@@ -1,7 +1,7 @@
 <html>
 <body>
-<embed data-content-id="1" type="application/x-google-chrome-surface-embed" />
-<embed data-content-id="2" type="application/x-google-chrome-surface-embed" />
-<embed data-content-id="3" type="application/x-google-chrome-surface-embed" />
+<embed data-content-id="1234567890ABCDEFFEDCBA0987654321" type="application/x-google-chrome-surface-embed" />
+<embed data-content-id="1234567890ABCDEFFEDCBA0987654322" type="application/x-google-chrome-surface-embed" />
+<embed data-content-id="1234567890ABCDEFFEDCBA0987654323" type="application/x-google-chrome-surface-embed" />
 </body>
 </html>

--- a/components/test/data/surface_embed/single_embed_attach_harness.html
+++ b/components/test/data/surface_embed/single_embed_attach_harness.html
@@ -9,7 +9,7 @@ body {
 </style>
 <script>
   let mutationObserver = null;
-  let zeroChangeDetected = false;
+  let emptyChangeDetected = false;
 
   // Create and attach the embed element. Called from the browser test with the
   // content_id. Optional embedId can be provided to give the embed an ID
@@ -54,7 +54,7 @@ body {
 
   // Start monitoring for changes to data-content-id to "0".
   function startMonitoringDataContentId() {
-    zeroChangeDetected = false;
+    emptyChangeDetected = false;
     const embed = document.querySelector('embed');
     if (!embed) return;
 
@@ -63,8 +63,8 @@ body {
         if (mutation.type === 'attributes' &&
             mutation.attributeName === 'data-content-id') {
           const newValue = embed.getAttribute('data-content-id');
-          if (newValue === '0') {
-            zeroChangeDetected = true;
+          if (newValue === '') {
+            emptyChangeDetected = true;
           }
         }
       }
@@ -84,9 +84,9 @@ body {
     }
   }
 
-  // Check if a data-content-id change to zero was detected.
-  function wasZeroChangeDetected() {
-    return zeroChangeDetected;
+  // Check if a data-content-id change to empty was detected.
+  function wasEmptyChangeDetected() {
+    return emptyChangeDetected;
   }
 </script>
 </head>

--- a/ui/webui/examples/browser/ui/web/browser.cc
+++ b/ui/webui/examples/browser/ui/web/browser.cc
@@ -54,7 +54,7 @@ Browser::Browser(content::WebUI* web_ui)
       guest_contents_.get());
   auto* guest_handle = guest_contents::GuestContentsHandle::FromWebContents(
       guest_contents_.get());
-  html_source->AddInteger("guest-contents-id", guest_handle->id());
+  html_source->AddString("guest-contents-id", guest_handle->id().ToString());
 }
 
 Browser::~Browser() {

--- a/ui/webui/examples/browser/ui/web/browser.mojom
+++ b/ui/webui/examples/browser/ui/web/browser.mojom
@@ -16,11 +16,11 @@ interface PageHandlerFactory {
 // Browser-side handler for requests from WebUI page.
 interface PageHandler {
   // Navigates the WebView with `guest_contents_id` to `src`.
-  Navigate(int32 guest_contents_id, url.mojom.Url src);
+  Navigate(string guest_contents_id, url.mojom.Url src);
 
   // Navigates the WebView with `guest_contents_id` to back in the nav stack.
-  GoBack(int32 guest_contents_id);
+  GoBack(string guest_contents_id);
 
   // Navigates the WebView with `guest_contents_id` to forward in the nav stack.
-  GoForward(int32 guest_contents_id);
+  GoForward(string guest_contents_id);
 };

--- a/ui/webui/examples/browser/ui/web/browser.mojom
+++ b/ui/webui/examples/browser/ui/web/browser.mojom
@@ -4,6 +4,7 @@
 
 module webui_examples.mojom;
 
+import "mojo/public/mojom/base/unguessable_token.mojom";
 import "mojo/public/mojom/base/values.mojom";
 import "url/mojom/url.mojom";
 
@@ -16,11 +17,12 @@ interface PageHandlerFactory {
 // Browser-side handler for requests from WebUI page.
 interface PageHandler {
   // Navigates the WebView with `guest_contents_id` to `src`.
-  Navigate(string guest_contents_id, url.mojom.Url src);
+  Navigate(mojo_base.mojom.UnguessableToken guest_contents_id,
+           url.mojom.Url src);
 
   // Navigates the WebView with `guest_contents_id` to back in the nav stack.
-  GoBack(string guest_contents_id);
+  GoBack(mojo_base.mojom.UnguessableToken guest_contents_id);
 
   // Navigates the WebView with `guest_contents_id` to forward in the nav stack.
-  GoForward(string guest_contents_id);
+  GoForward(mojo_base.mojom.UnguessableToken guest_contents_id);
 };

--- a/ui/webui/examples/browser/ui/web/browser_page_handler.cc
+++ b/ui/webui/examples/browser/ui/web/browser_page_handler.cc
@@ -26,13 +26,14 @@ BrowserPageHandler* BrowserPageHandler::Create(
                                 std::move(receiver));
 }
 
-void BrowserPageHandler::Navigate(int32_t guest_instance_id, const GURL& src) {
+void BrowserPageHandler::Navigate(const std::string& guest_instance_id,
+                                  const GURL& src) {
   content::WebContents* guest_contents = webui_controller()->guest_contents();
   content::NavigationController::LoadURLParams load_url_params(src);
   guest_contents->GetController().LoadURLWithParams(load_url_params);
 }
 
-void BrowserPageHandler::GoBack(int32_t guest_instance_id) {
+void BrowserPageHandler::GoBack(const std::string& guest_instance_id) {
   content::WebContents* guest_contents = webui_controller()->guest_contents();
   auto& navigation_controller = guest_contents->GetController();
   if (navigation_controller.CanGoBack()) {
@@ -40,7 +41,7 @@ void BrowserPageHandler::GoBack(int32_t guest_instance_id) {
   }
 }
 
-void BrowserPageHandler::GoForward(int32_t guest_instance_id) {
+void BrowserPageHandler::GoForward(const std::string& guest_instance_id) {
   content::WebContents* guest_contents = webui_controller()->guest_contents();
   auto& navigation_controller = guest_contents->GetController();
   if (navigation_controller.CanGoForward()) {

--- a/ui/webui/examples/browser/ui/web/browser_page_handler.cc
+++ b/ui/webui/examples/browser/ui/web/browser_page_handler.cc
@@ -26,14 +26,16 @@ BrowserPageHandler* BrowserPageHandler::Create(
                                 std::move(receiver));
 }
 
-void BrowserPageHandler::Navigate(const std::string& guest_instance_id,
-                                  const GURL& src) {
+void BrowserPageHandler::Navigate(
+    const base::UnguessableToken& guest_instance_id,
+    const GURL& src) {
   content::WebContents* guest_contents = webui_controller()->guest_contents();
   content::NavigationController::LoadURLParams load_url_params(src);
   guest_contents->GetController().LoadURLWithParams(load_url_params);
 }
 
-void BrowserPageHandler::GoBack(const std::string& guest_instance_id) {
+void BrowserPageHandler::GoBack(
+    const base::UnguessableToken& guest_instance_id) {
   content::WebContents* guest_contents = webui_controller()->guest_contents();
   auto& navigation_controller = guest_contents->GetController();
   if (navigation_controller.CanGoBack()) {
@@ -41,7 +43,8 @@ void BrowserPageHandler::GoBack(const std::string& guest_instance_id) {
   }
 }
 
-void BrowserPageHandler::GoForward(const std::string& guest_instance_id) {
+void BrowserPageHandler::GoForward(
+    const base::UnguessableToken& guest_instance_id) {
   content::WebContents* guest_contents = webui_controller()->guest_contents();
   auto& navigation_controller = guest_contents->GetController();
   if (navigation_controller.CanGoForward()) {

--- a/ui/webui/examples/browser/ui/web/browser_page_handler.h
+++ b/ui/webui/examples/browser/ui/web/browser_page_handler.h
@@ -31,9 +31,9 @@ class BrowserPageHandler
       mojo::PendingReceiver<webui_examples::mojom::PageHandler> receiver);
 
   // webui_examples::mojom::PageHandler
-  void Navigate(int32_t guest_instance_id, const GURL& src) override;
-  void GoBack(int32_t guest_instance_id) override;
-  void GoForward(int32_t guest_instance_id) override;
+  void Navigate(const std::string& guest_instance_id, const GURL& src) override;
+  void GoBack(const std::string& guest_instance_id) override;
+  void GoForward(const std::string& guest_instance_id) override;
 
   // The WebUI controller goes away before the Document. Clear the raw_ptr
   // to the controller to avoid it becoming dangling.

--- a/ui/webui/examples/browser/ui/web/browser_page_handler.h
+++ b/ui/webui/examples/browser/ui/web/browser_page_handler.h
@@ -31,9 +31,10 @@ class BrowserPageHandler
       mojo::PendingReceiver<webui_examples::mojom::PageHandler> receiver);
 
   // webui_examples::mojom::PageHandler
-  void Navigate(const std::string& guest_instance_id, const GURL& src) override;
-  void GoBack(const std::string& guest_instance_id) override;
-  void GoForward(const std::string& guest_instance_id) override;
+  void Navigate(const base::UnguessableToken& guest_instance_id,
+                const GURL& src) override;
+  void GoBack(const base::UnguessableToken& guest_instance_id) override;
+  void GoForward(const base::UnguessableToken& guest_instance_id) override;
 
   // The WebUI controller goes away before the Document. Clear the raw_ptr
   // to the controller to avoid it becoming dangling.

--- a/ui/webui/examples/renderer/render_frame_observer.cc
+++ b/ui/webui/examples/renderer/render_frame_observer.cc
@@ -70,7 +70,7 @@ content::RenderFrame* GetRenderFrame(v8::Local<v8::Value> value) {
   return content::RenderFrame::FromWebFrame(frame);
 }
 
-void AttachIframeGuest(int guest_contents_id,
+void AttachIframeGuest(const std::string& guest_contents_id,
                        v8::Local<v8::Object> content_window) {
   // attachIframeGuest(guestInstanceId, contentWindow)
   // Getting the attach params could destroy the frame while it executes JS,
@@ -86,7 +86,12 @@ void AttachIframeGuest(int guest_contents_id,
   CHECK(parent_frame);
   CHECK(parent_frame->IsWebLocalFrame());
 
-  guest_contents::renderer::SwapRenderFrame(render_frame, guest_contents_id);
+  auto parsed_guest_contents_id =
+      base::UnguessableToken::DeserializeFromString(guest_contents_id);
+  CHECK(parsed_guest_contents_id.has_value());
+
+  guest_contents::renderer::SwapRenderFrame(render_frame,
+                                            *parsed_guest_contents_id);
 }
 
 }  // namespace

--- a/ui/webui/examples/resources/browser/index.ts
+++ b/ui/webui/examples/resources/browser/index.ts
@@ -10,8 +10,7 @@ import '/strings.m.js';
 
 interface WebshellServices {
   allowWebviewElementRegistration(callback: ()=>void): void;
-  attachIframeGuest(guestContentsId: number,
-                    contentWindow: Window | null): void
+  attachIframeGuest(guestContentsId: string, contentWindow: Window|null): void
 }
 
 declare var webshell: WebshellServices;
@@ -40,7 +39,7 @@ class BrowserProxy {
 
 class WebviewElement extends HTMLElement {
   public iframeElement: HTMLIFrameElement;
-  private guestContentsId: number;
+  private guestContentsId: string;
   private attached: boolean = false;
 
   constructor() {
@@ -50,7 +49,7 @@ class WebviewElement extends HTMLElement {
     this.iframeElement.style.margin = "0";
     this.iframeElement.style.padding = "0";
     this.iframeElement.style.flex = '1';
-    this.guestContentsId = loadTimeData.getInteger('guest-contents-id');
+    this.guestContentsId = loadTimeData.getString('guest-contents-id');
     console.log('guest-contents-id', this.guestContentsId);
   }
 
@@ -78,7 +77,7 @@ class WebviewElement extends HTMLElement {
 
 class SurfaceEmbedElement extends HTMLElement {
   public embedElement: HTMLEmbedElement;
-  private guestContentsId: number;
+  private guestContentsId: string;
   private attached: boolean = false;
 
   constructor() {
@@ -88,10 +87,9 @@ class SurfaceEmbedElement extends HTMLElement {
     this.embedElement.style.margin = '0';
     this.embedElement.style.padding = '0';
     this.embedElement.style.flex = '1';
-    this.guestContentsId = loadTimeData.getInteger('guest-contents-id');
+    this.guestContentsId = loadTimeData.getString('guest-contents-id');
     console.log('surface-embed guest-contents-id', this.guestContentsId);
-    this.embedElement.setAttribute(
-        'data-content-id', this.guestContentsId.toString());
+    this.embedElement.setAttribute('data-content-id', this.guestContentsId);
     this.embedElement.setAttribute(
         'type', 'application/x-google-chrome-surface-embed');
   }


### PR DESCRIPTION
So my plan with this is:
1) Review this here first, since there are some non-trivial interactions w/tests and attribute semantics.
2) Extract out the portion for main Chromium repo, review + land it here
3) Re-sync the CL here with any changes.
